### PR TITLE
Target flatbuffer schema update

### DIFF
--- a/buildcc/lib/target/fbs/target.fbs
+++ b/buildcc/lib/target/fbs/target.fbs
@@ -14,16 +14,6 @@
 
 namespace schema.internal;
 
-// TODO, Custom executables
-table Toolchain {
-    name:string (key);
-    asm_compiler:string;
-    c_compiler:string;
-    cpp_compiler:string;
-    archiver:string;
-    linker:string;
-}
-
 table Path {
     pathname:string (key);
     last_write_timestamp:uint64;
@@ -35,11 +25,10 @@ enum TargetType : byte {
     DynamicLibrary
 }
 
+// TODO, Check if Toolchain needs to be added to Target
 table Target {
     name:string (key);
-    relative_path:string;
     type:TargetType;
-    toolchain:Toolchain;
 
     // Files
     source_files:[Path];

--- a/buildcc/lib/target/src/fbs/fbs_loader.cpp
+++ b/buildcc/lib/target/src/fbs/fbs_loader.cpp
@@ -67,6 +67,14 @@ bool FbsLoader::Load() {
   if (!is_loaded) {
     return false;
   }
+
+  flatbuffers::Verifier verifier((const uint8_t *)buffer.c_str(),
+                                 buffer.length());
+  const bool is_verified = fbs::VerifyTargetBuffer(verifier);
+  if (!is_verified) {
+    return false;
+  }
+
   const auto *target = fbs::GetTarget((const void *)buffer.c_str());
   // target->name()->c_str();
   // target->relative_path()->c_str();

--- a/buildcc/lib/target/src/fbs/fbs_loader.cpp
+++ b/buildcc/lib/target/src/fbs/fbs_loader.cpp
@@ -77,9 +77,8 @@ bool FbsLoader::Load() {
 
   const auto *target = fbs::GetTarget((const void *)buffer.c_str());
   // target->name()->c_str();
-  // target->relative_path()->c_str();
   // target->type();
-  // target->toolchain();
+
   Extract(target->source_files(), loaded_sources_);
   Extract(target->header_files(), loaded_headers_);
   Extract(target->lib_deps(), loaded_lib_deps_);

--- a/buildcc/lib/target/src/fbs/fbs_storer.cpp
+++ b/buildcc/lib/target/src/fbs/fbs_storer.cpp
@@ -29,18 +29,7 @@ namespace fbs = schema::internal;
 namespace {
 
 fbs::TargetType get_fbs_target_type(buildcc::base::TargetType type) {
-  fbs::TargetType target_type = fbs::TargetType_Executable;
-  switch (type) {
-  case buildcc::base::TargetType::Executable:
-    break;
-  case buildcc::base::TargetType::StaticLibrary:
-    target_type = fbs::TargetType::TargetType_StaticLibrary;
-    break;
-  case buildcc::base::TargetType::DynamicLibrary:
-    target_type = fbs::TargetType_DynamicLibrary;
-    break;
-  }
-  return target_type;
+  return (fbs::TargetType)type;
 }
 
 std::vector<flatbuffers::Offset<fbs::Path>>

--- a/buildcc/lib/target/src/fbs/fbs_storer.cpp
+++ b/buildcc/lib/target/src/fbs/fbs_storer.cpp
@@ -43,16 +43,6 @@ fbs::TargetType get_fbs_target_type(buildcc::base::TargetType type) {
   return target_type;
 }
 
-// TODO, Complete this with additional flags
-flatbuffers::Offset<fbs::Toolchain>
-get_fbs_toolchain(flatbuffers::FlatBufferBuilder &builder,
-                  const buildcc::base::Toolchain &toolchain) {
-  return fbs::CreateToolchainDirect(
-      builder, toolchain.GetName().c_str(), toolchain.GetAsmCompiler().c_str(),
-      toolchain.GetCCompiler().c_str(), toolchain.GetCppCompiler().c_str(),
-      toolchain.GetArchiver().c_str(), toolchain.GetLinker().c_str());
-}
-
 std::vector<flatbuffers::Offset<fbs::Path>>
 get_fbs_vector_path(flatbuffers::FlatBufferBuilder &builder,
                     const buildcc::internal::path_unordered_set &pathlist) {
@@ -87,7 +77,6 @@ bool Target::Store() {
   flatbuffers::FlatBufferBuilder builder;
 
   auto fbs_target_type = get_fbs_target_type(type_);
-  auto fbs_toolchain = get_fbs_toolchain(builder, toolchain_);
 
   auto fbs_source_files = get_fbs_vector_path(builder, current_source_files_);
   auto fbs_header_files = get_fbs_vector_path(builder, current_header_files_);
@@ -108,11 +97,10 @@ bool Target::Store() {
   auto fbs_link_flags = get_fbs_vector_string(builder, current_link_flags_);
 
   auto fbs_target = fbs::CreateTargetDirect(
-      builder, name_.c_str(), target_intermediate_dir_.string().c_str(),
-      fbs_target_type, fbs_toolchain, &fbs_source_files, &fbs_header_files,
-      &fbs_lib_deps, &fbs_external_lib_deps, &fbs_include_dirs, &fbs_lib_dirs,
-      &fbs_preprocessor_flags, &fbs_c_compiler_flags, &fbs_cpp_compiler_flags,
-      &fbs_link_flags);
+      builder, name_.c_str(), fbs_target_type, &fbs_source_files,
+      &fbs_header_files, &fbs_lib_deps, &fbs_external_lib_deps,
+      &fbs_include_dirs, &fbs_lib_dirs, &fbs_preprocessor_flags,
+      &fbs_c_compiler_flags, &fbs_cpp_compiler_flags, &fbs_link_flags);
   fbs::FinishTargetBuffer(builder, fbs_target);
 
   auto file_path = GetBinaryPath();


### PR DESCRIPTION
- Do not track `Toolchain` and  `relative_path` in Flatbuffer schema
- Updated fbs_storer with the updated schema
- Updated fbs_loader with verifier
