### PR TITLE
[FIX] Add lib dep

### DIFF
--- a/buildcc/lib/target/include/target.h
+++ b/buildcc/lib/target/include/target.h
@@ -154,6 +154,12 @@ public:
   const internal::path_unordered_set &GetCurrentHeaderFiles() const {
     return current_header_files_;
   }
+  const std::unordered_set<const Target *> &GetTargetLibDeps() const {
+    return target_lib_deps_;
+  }
+  const internal::fs_unordered_set &GetCurrentIncludeDirs() const {
+    return current_include_dirs_;
+  }
 
   bool FirstBuild() const { return first_build_; }
   bool Rebuild() const { return rebuild_; }
@@ -249,7 +255,9 @@ private:
       current_object_files_;
 
   internal::path_unordered_set current_header_files_;
+
   internal::path_unordered_set current_lib_deps_;
+  std::unordered_set<const base::Target *> target_lib_deps_;
 
   internal::fs_unordered_set current_include_dirs_;
   internal::fs_unordered_set current_lib_dirs_;

--- a/buildcc/lib/target/include/target.h
+++ b/buildcc/lib/target/include/target.h
@@ -257,7 +257,7 @@ private:
   internal::path_unordered_set current_header_files_;
 
   internal::path_unordered_set current_lib_deps_;
-  std::unordered_set<const base::Target *> target_lib_deps_;
+  std::unordered_set<const Target *> target_lib_deps_;
 
   internal::fs_unordered_set current_include_dirs_;
   internal::fs_unordered_set current_lib_dirs_;

--- a/buildcc/lib/target/mock/target/tasks.cpp
+++ b/buildcc/lib/target/mock/target/tasks.cpp
@@ -15,7 +15,17 @@ void Target::CompileTargetTask(
 
 void Target::LinkTargetTask(const bool link) {
   if (link) {
+    dirty_ = true;
+  }
+  std::for_each(target_lib_deps_.cbegin(), target_lib_deps_.cend(),
+                [this](const Target *target) {
+                  current_lib_deps_.insert(internal::Path::CreateExistingPath(
+                      target->GetTargetPath()));
+                });
+  RecheckPaths(loader_.GetLoadedLibDeps(), current_lib_deps_);
+  if (dirty_) {
     LinkTarget();
+    Store();
   }
 }
 

--- a/buildcc/lib/target/src/target/lib.cpp
+++ b/buildcc/lib/target/src/target/lib.cpp
@@ -38,8 +38,7 @@ void Target::AddLibDirAbsolute(const fs::path &absolute_lib_dir) {
 void Target::AddLibDep(const Target &lib_dep) {
   env::log_trace(name_, __FUNCTION__);
 
-  const fs::path lib_dep_path = lib_dep.GetTargetPath();
-  internal::add_path(lib_dep_path, current_lib_deps_);
+  target_lib_deps_.insert(&lib_dep);
 }
 
 void Target::AddLibDep(const std::string &lib_dep) {

--- a/buildcc/lib/target/src/target/tasks.cpp
+++ b/buildcc/lib/target/src/target/tasks.cpp
@@ -16,6 +16,8 @@
 
 #include "target.h"
 
+#include <algorithm>
+
 #include "assert_fatal.h"
 #include "logging.h"
 

--- a/doc/custom_target/commands.md
+++ b/doc/custom_target/commands.md
@@ -26,7 +26,6 @@ See [build.cpp Target::Build API](../../buildcc/lib/target/src/target/build.cpp)
 
 - `include_dirs`: Aggregated include directories for header files
 - `lib_dirs`: Aggregated lib directories for external libraries
-- `lib_deps`: External libraries and full path libraries
 - `preprocessor_flags`: Preprocessor definitions
 - `link_flags`: Flags supplied during linking
 - `asm_compiler`: Assembly compiler
@@ -50,3 +49,4 @@ See [build.cpp Target::Target API](../../buildcc/lib/target/src/target/build.cpp
 
 - `output`: Generated target as `Target::GetName()`
 - `compiled_sources`: Aggregated object files
+- `lib_deps`: External libraries and full path libraries


### PR DESCRIPTION
# Problem
After `Taskflow` was integrated the `Target::AddLibDep(const base::Target & target)` API did not work

This is because `AddLibDep` checked for the physical presence of the library file
Using the `Taskflow` APIs the targets are not built before the `executor` runs

# Solution

- Store the `const base::Target & target` as a list/set `unordered_set<const Target *>`
- Make sure that the physical presence of the library file is verified only inside the `Taskflow` Task functions
  - We can then guarantee that the dependency is built through Taskflow dependency management
- Update other Target functions that depend on the physical presence of the library file AND move them inside the Task.

