### PR TITLE
[Fix] Generated dependencies

### DIFF
--- a/buildcc/lib/target/include/target/generator.h
+++ b/buildcc/lib/target/include/target/generator.h
@@ -32,27 +32,16 @@
 
 namespace buildcc::base {
 
-struct UserGenInfo {
-  std::string name;
-  internal::fs_unordered_set inputs;
-  internal::fs_unordered_set outputs;
-  std::vector<std::string> commands;
-  bool parallel{false};
-
-  explicit UserGenInfo(const std::string &n,
-                       const internal::fs_unordered_set &i,
-                       const internal::fs_unordered_set &o,
-                       const std::vector<std::string> &c, bool p)
-      : name(n), inputs(i), outputs(o), commands(c), parallel(p) {}
-};
-
 class Generator : public BuilderInterface {
 public:
   Generator(const std::string &name, const fs::path &path)
       : loader_(name, path) {}
   Generator(const Generator &generator) = delete;
 
-  void AddGenInfo(const UserGenInfo &info);
+  void AddGenInfo(const std::string &name,
+                  const internal::fs_unordered_set &inputs,
+                  const internal::fs_unordered_set &outputs,
+                  const std::vector<std::string> &commands, bool parallel);
   void Build() override;
 
   // Getter
@@ -78,7 +67,6 @@ private:
 
 private:
   std::string name_;
-  std::unordered_map<std::string, UserGenInfo> user_info_;
   std::unordered_map<std::string, internal::GenInfo> current_info_;
 
   internal::GeneratorLoader loader_;

--- a/buildcc/lib/target/include/target/generator_loader.h
+++ b/buildcc/lib/target/include/target/generator_loader.h
@@ -31,15 +31,35 @@ namespace buildcc::internal {
 
 struct GenInfo {
   std::string name;
-  path_unordered_set inputs;
+  Files<fs_unordered_set> inputs;
   fs_unordered_set outputs;
   std::vector<std::string> commands;
   bool parallel{false};
 
-  explicit GenInfo(const std::string &n, const path_unordered_set &i,
-                   const fs_unordered_set &o, const std::vector<std::string> &c,
-                   bool p)
-      : name(n), inputs(i), outputs(o), commands(c), parallel(p) {}
+  static GenInfo CreateInternalGenInfo(const std::string &n,
+                                       const path_unordered_set &internal_i,
+                                       const fs_unordered_set &o,
+                                       const std::vector<std::string> &c,
+                                       bool p) {
+    return GenInfo(n, internal_i, {}, o, c, p);
+  }
+
+  static GenInfo CreateUserGenInfo(const std::string &n,
+                                   const fs_unordered_set &user_i,
+                                   const fs_unordered_set &o,
+                                   const std::vector<std::string> &c, bool p) {
+    return GenInfo(n, {}, user_i, o, c, p);
+  }
+
+  GenInfo(GenInfo &&info) = default;
+  GenInfo(const GenInfo &info) = delete;
+
+private:
+  explicit GenInfo(const std::string &n, const path_unordered_set &internal_i,
+                   const fs_unordered_set &user_i, const fs_unordered_set &o,
+                   const std::vector<std::string> &c, bool p)
+      : name(n), inputs(internal_i, user_i), outputs(o), commands(c),
+        parallel(p) {}
 };
 
 typedef std::unordered_map<std::string, GenInfo> geninfo_unordered_map;

--- a/buildcc/lib/target/include/target/path.h
+++ b/buildcc/lib/target/include/target/path.h
@@ -120,6 +120,20 @@ public:
 typedef std::unordered_set<Path, PathHash> path_unordered_set;
 typedef std::unordered_set<fs::path, PathHash> fs_unordered_set;
 
+// * Relation between
+// - internal timestamp verified files (Path + Timestamp)
+// - user facing file paths (Only Path)
+// ? Why has this been done?
+// We cannot guarantee that filepaths would be present
+// when the user is defining the build
+// The input to a Generator / Target might also be generated!
+// We must only verify the File timestamp AFTER dependent Generator(s) /
+// Target(s) have been built
+template <typename T> struct Files {
+  path_unordered_set internal;
+  T user;
+};
+
 } // namespace buildcc::internal
 
 #endif

--- a/buildcc/lib/target/include/target/path.h
+++ b/buildcc/lib/target/include/target/path.h
@@ -132,6 +132,9 @@ typedef std::unordered_set<fs::path, PathHash> fs_unordered_set;
 template <typename T> struct Files {
   path_unordered_set internal;
   T user;
+
+  Files() {}
+  Files(const path_unordered_set &i, const T &u) : internal(i), user(u) {}
 };
 
 } // namespace buildcc::internal

--- a/buildcc/lib/target/include/target/target.h
+++ b/buildcc/lib/target/include/target/target.h
@@ -176,8 +176,8 @@ public:
   const internal::fs_unordered_set &GetCurrentSourceFiles() const {
     return current_source_files_.user;
   }
-  const internal::path_unordered_set &GetCurrentHeaderFiles() const {
-    return current_header_files_;
+  const internal::fs_unordered_set &GetCurrentHeaderFiles() const {
+    return current_header_files_.user;
   }
   const std::unordered_set<const Target *> &GetTargetLibDeps() const {
     return target_lib_deps_;
@@ -283,7 +283,7 @@ private:
   std::unordered_map<fs::path, internal::Path, internal::PathHash>
       current_object_files_;
 
-  internal::path_unordered_set current_header_files_;
+  internal::Files<internal::fs_unordered_set> current_header_files_;
 
   internal::path_unordered_set current_lib_deps_;
   std::unordered_set<const Target *> target_lib_deps_;

--- a/buildcc/lib/target/include/target/target.h
+++ b/buildcc/lib/target/include/target/target.h
@@ -222,7 +222,8 @@ private:
   void Initialize();
 
   //
-  void Convert();
+  void ConvertForCompile();
+  void ConvertForLink();
 
   // Build
   void BuildCompile(std::vector<fs::path> &compile_sources,

--- a/buildcc/lib/target/include/target/target.h
+++ b/buildcc/lib/target/include/target/target.h
@@ -173,8 +173,8 @@ public:
   // TODO, Consider returning `std::vector<std::string>` OR
   // `std::vector<fs::path>` for these getters
   // These APIs are meant to be consumed by users
-  const internal::path_unordered_set &GetCurrentSourceFiles() const {
-    return current_source_files_;
+  const internal::fs_unordered_set &GetCurrentSourceFiles() const {
+    return user_source_files_;
   }
   const internal::path_unordered_set &GetCurrentHeaderFiles() const {
     return current_header_files_;
@@ -220,6 +220,9 @@ protected:
 
 private:
   void Initialize();
+
+  //
+  void Convert();
 
   // Build
   void BuildCompile(std::vector<fs::path> &compile_sources,
@@ -274,6 +277,7 @@ private:
   fs::path target_intermediate_dir_;
 
   // Internal
+  internal::fs_unordered_set user_source_files_;
   internal::path_unordered_set current_source_files_;
   // NOTE, Always store the absolute source path -> absolute compiled source
   // path here

--- a/buildcc/lib/target/include/target/target.h
+++ b/buildcc/lib/target/include/target/target.h
@@ -298,8 +298,8 @@ private:
   std::unordered_set<std::string> current_cpp_compile_flags_;
   std::unordered_set<std::string> current_link_flags_;
 
-  internal::path_unordered_set current_compile_dependencies_;
-  internal::path_unordered_set current_link_dependencies_;
+  internal::Files<internal::fs_unordered_set> current_compile_dependencies_;
+  internal::Files<internal::fs_unordered_set> current_link_dependencies_;
 
   // TODO, Might not need to be persistent
   std::string aggregated_c_compile_flags_;

--- a/buildcc/lib/target/include/target/target.h
+++ b/buildcc/lib/target/include/target/target.h
@@ -180,7 +180,7 @@ public:
     return current_header_files_.user;
   }
   const std::unordered_set<const Target *> &GetTargetLibDeps() const {
-    return target_lib_deps_;
+    return current_lib_deps_.user;
   }
   const internal::fs_unordered_set &GetCurrentIncludeDirs() const {
     return current_include_dirs_;
@@ -285,8 +285,7 @@ private:
 
   internal::Files<internal::fs_unordered_set> current_header_files_;
 
-  internal::path_unordered_set current_lib_deps_;
-  std::unordered_set<const Target *> target_lib_deps_;
+  internal::Files<std::unordered_set<const Target *>> current_lib_deps_;
 
   internal::fs_unordered_set current_include_dirs_;
   internal::fs_unordered_set current_lib_dirs_;

--- a/buildcc/lib/target/include/target/target.h
+++ b/buildcc/lib/target/include/target/target.h
@@ -174,7 +174,7 @@ public:
   // `std::vector<fs::path>` for these getters
   // These APIs are meant to be consumed by users
   const internal::fs_unordered_set &GetCurrentSourceFiles() const {
-    return user_source_files_;
+    return current_source_files_.user;
   }
   const internal::path_unordered_set &GetCurrentHeaderFiles() const {
     return current_header_files_;
@@ -277,8 +277,7 @@ private:
   fs::path target_intermediate_dir_;
 
   // Internal
-  internal::fs_unordered_set user_source_files_;
-  internal::path_unordered_set current_source_files_;
+  internal::Files<internal::fs_unordered_set> current_source_files_;
   // NOTE, Always store the absolute source path -> absolute compiled source
   // path here
   std::unordered_map<fs::path, internal::Path, internal::PathHash>

--- a/buildcc/lib/target/include/target/util.h
+++ b/buildcc/lib/target/include/target/util.h
@@ -24,19 +24,6 @@
 
 namespace buildcc::internal {
 
-// Additions
-/**
- * @brief Existing path is stored inside stored_paths
- * Returns false if path is stored
- * Throws buildcc::env::assert_exception if path does not exist
- *
- * @param path
- * @param stored_paths
- * @return true
- * @return false
- */
-bool add_path(const fs::path &path, path_unordered_set &stored_paths);
-
 // Checks
 /**
  * @brief Perform check to see if previous path is present in current path

--- a/buildcc/lib/target/mock/target/tasks.cpp
+++ b/buildcc/lib/target/mock/target/tasks.cpp
@@ -5,6 +5,8 @@
 namespace buildcc::base {
 
 void Target::CompileTask() {
+  Convert();
+
   std::vector<fs::path> compile_sources;
   std::vector<fs::path> dummy_sources;
   BuildCompile(compile_sources, dummy_sources);

--- a/buildcc/lib/target/mock/target/tasks.cpp
+++ b/buildcc/lib/target/mock/target/tasks.cpp
@@ -5,7 +5,7 @@
 namespace buildcc::base {
 
 void Target::CompileTask() {
-  Convert();
+  ConvertForCompile();
 
   std::vector<fs::path> compile_sources;
   std::vector<fs::path> dummy_sources;
@@ -16,6 +16,9 @@ void Target::CompileTask() {
   }
 }
 
-void Target::LinkTask() { BuildLink(); }
+void Target::LinkTask() {
+  ConvertForLink();
+  BuildLink();
+}
 
 } // namespace buildcc::base

--- a/buildcc/lib/target/src/generator/generator_loader.cpp
+++ b/buildcc/lib/target/src/generator/generator_loader.cpp
@@ -53,9 +53,9 @@ bool GeneratorLoader::Load() {
     ExtractPath(iter->inputs(), i);
     Extract(iter->outputs(), o);
     Extract(iter->commands(), c);
-    loaded_info_.insert(
-        std::make_pair(iter->name()->c_str(), GenInfo(iter->name()->c_str(), i,
-                                                      o, c, iter->parallel())));
+    loaded_info_.emplace(iter->name()->c_str(),
+                         GenInfo::CreateInternalGenInfo(
+                             iter->name()->c_str(), i, o, c, iter->parallel()));
   }
 
   loaded_ = true;

--- a/buildcc/lib/target/src/generator/generator_storer.cpp
+++ b/buildcc/lib/target/src/generator/generator_storer.cpp
@@ -35,7 +35,8 @@ bool Generator::Store() {
   std::vector<flatbuffers::Offset<fbs::GenInfo>> fbs_generator_list;
   for (const auto &info : current_info_) {
     const auto &geninfo = info.second;
-    auto fbs_inputs = internal::CreateFbsVectorPath(builder, geninfo.inputs);
+    auto fbs_inputs =
+        internal::CreateFbsVectorPath(builder, geninfo.inputs.internal);
     auto fbs_outputs =
         internal::CreateFbsVectorString(builder, geninfo.outputs);
     auto fbs_commands =

--- a/buildcc/lib/target/src/target/build.cpp
+++ b/buildcc/lib/target/src/target/build.cpp
@@ -72,6 +72,12 @@ void Target::Convert() {
     current_source_files_.internal.emplace(
         buildcc::internal::Path::CreateExistingPath(user_sf));
   }
+
+  // Convert user_header_files to current_header_files
+  for (const auto &user_hf : current_header_files_.user) {
+    current_header_files_.internal.emplace(
+        buildcc::internal::Path::CreateExistingPath(user_hf));
+  }
 }
 
 void Target::BuildCompile(std::vector<fs::path> &compile_sources,
@@ -92,7 +98,7 @@ void Target::BuildCompile(std::vector<fs::path> &compile_sources,
     RecheckFlags(loader_.GetLoadedCppCompileFlags(),
                  current_cpp_compile_flags_);
     RecheckDirs(loader_.GetLoadedIncludeDirs(), current_include_dirs_);
-    RecheckPaths(loader_.GetLoadedHeaders(), current_header_files_);
+    RecheckPaths(loader_.GetLoadedHeaders(), current_header_files_.internal);
     RecheckPaths(loader_.GetLoadedCompileDependencies(),
                  current_compile_dependencies_);
 

--- a/buildcc/lib/target/src/target/build.cpp
+++ b/buildcc/lib/target/src/target/build.cpp
@@ -64,6 +64,16 @@ void Target::Build() {
   LinkTask();
 }
 
+//
+
+void Target::Convert() {
+  // Convert user_source_files to current_source_files
+  for (const auto &user_sf : user_source_files_) {
+    current_source_files_.emplace(
+        buildcc::internal::Path::CreateExistingPath(user_sf));
+  }
+}
+
 void Target::BuildCompile(std::vector<fs::path> &compile_sources,
                           std::vector<fs::path> &dummy_sources) {
   const bool is_loaded = loader_.Load();

--- a/buildcc/lib/target/src/target/build.cpp
+++ b/buildcc/lib/target/src/target/build.cpp
@@ -68,8 +68,8 @@ void Target::Build() {
 
 void Target::Convert() {
   // Convert user_source_files to current_source_files
-  for (const auto &user_sf : user_source_files_) {
-    current_source_files_.emplace(
+  for (const auto &user_sf : current_source_files_.user) {
+    current_source_files_.internal.emplace(
         buildcc::internal::Path::CreateExistingPath(user_sf));
   }
 }

--- a/buildcc/lib/target/src/target/build.cpp
+++ b/buildcc/lib/target/src/target/build.cpp
@@ -66,7 +66,7 @@ void Target::Build() {
 
 //
 
-void Target::Convert() {
+void Target::ConvertForCompile() {
   // Convert user_source_files to current_source_files
   for (const auto &user_sf : current_source_files_.user) {
     current_source_files_.internal.emplace(
@@ -82,6 +82,20 @@ void Target::Convert() {
   for (const auto &user_cd : current_compile_dependencies_.user) {
     current_compile_dependencies_.internal.emplace(
         internal::Path::CreateExistingPath(user_cd));
+  }
+}
+
+void Target::ConvertForLink() {
+  std::for_each(
+      current_lib_deps_.user.cbegin(), current_lib_deps_.user.cend(),
+      [this](const Target *target) {
+        current_lib_deps_.internal.emplace(
+            internal::Path::CreateExistingPath(target->GetTargetPath()));
+      });
+
+  for (const auto &user_ld : current_link_dependencies_.user) {
+    current_link_dependencies_.internal.emplace(
+        internal::Path::CreateExistingPath(user_ld));
   }
 }
 
@@ -118,19 +132,6 @@ void Target::BuildCompile(std::vector<fs::path> &compile_sources,
 }
 
 void Target::BuildLink() {
-  // Convert
-  std::for_each(
-      current_lib_deps_.user.cbegin(), current_lib_deps_.user.cend(),
-      [this](const Target *target) {
-        current_lib_deps_.internal.emplace(
-            internal::Path::CreateExistingPath(target->GetTargetPath()));
-      });
-
-  for (const auto &user_ld : current_link_dependencies_.user) {
-    current_link_dependencies_.internal.emplace(
-        internal::Path::CreateExistingPath(user_ld));
-  }
-
   // * Completely rebuild target / link if any of the following change
   // Target compiled source files either during Compile / Recompile
   // Target library dependencies

--- a/buildcc/lib/target/src/target/build.cpp
+++ b/buildcc/lib/target/src/target/build.cpp
@@ -78,6 +78,11 @@ void Target::Convert() {
     current_header_files_.internal.emplace(
         buildcc::internal::Path::CreateExistingPath(user_hf));
   }
+
+  for (const auto &user_cd : current_compile_dependencies_.user) {
+    current_compile_dependencies_.internal.emplace(
+        internal::Path::CreateExistingPath(user_cd));
+  }
 }
 
 void Target::BuildCompile(std::vector<fs::path> &compile_sources,
@@ -100,7 +105,7 @@ void Target::BuildCompile(std::vector<fs::path> &compile_sources,
     RecheckDirs(loader_.GetLoadedIncludeDirs(), current_include_dirs_);
     RecheckPaths(loader_.GetLoadedHeaders(), current_header_files_.internal);
     RecheckPaths(loader_.GetLoadedCompileDependencies(),
-                 current_compile_dependencies_);
+                 current_compile_dependencies_.internal);
 
     // * Compile sources
     if (dirty_) {
@@ -121,6 +126,11 @@ void Target::BuildLink() {
             internal::Path::CreateExistingPath(target->GetTargetPath()));
       });
 
+  for (const auto &user_ld : current_link_dependencies_.user) {
+    current_link_dependencies_.internal.emplace(
+        internal::Path::CreateExistingPath(user_ld));
+  }
+
   // * Completely rebuild target / link if any of the following change
   // Target compiled source files either during Compile / Recompile
   // Target library dependencies
@@ -128,7 +138,8 @@ void Target::BuildLink() {
   RecheckDirs(loader_.GetLoadedLibDirs(), current_lib_dirs_);
   RecheckExternalLib(loader_.GetLoadedExternalLibDeps(),
                      current_external_lib_deps_);
-  RecheckPaths(loader_.GetLoadedLinkDependencies(), current_link_dependencies_);
+  RecheckPaths(loader_.GetLoadedLinkDependencies(),
+               current_link_dependencies_.internal);
   RecheckPaths(loader_.GetLoadedLibDeps(), current_lib_deps_.internal);
 
   if (dirty_) {

--- a/buildcc/lib/target/src/target/include_dir.cpp
+++ b/buildcc/lib/target/src/target/include_dir.cpp
@@ -29,8 +29,7 @@ void Target::AddHeaderAbsolute(const fs::path &absolute_filepath) {
   env::assert_fatal(IsValidHeader(absolute_filepath),
                     fmt::format("{} does not have a valid header extension",
                                 absolute_filepath.string()));
-  current_header_files_.emplace(
-      internal::Path::CreateExistingPath(absolute_filepath));
+  current_header_files_.user.insert(absolute_filepath);
 }
 
 void Target::AddHeader(const fs::path &relative_filename,

--- a/buildcc/lib/target/src/target/include_dir.cpp
+++ b/buildcc/lib/target/src/target/include_dir.cpp
@@ -29,7 +29,8 @@ void Target::AddHeaderAbsolute(const fs::path &absolute_filepath) {
   env::assert_fatal(IsValidHeader(absolute_filepath),
                     fmt::format("{} does not have a valid header extension",
                                 absolute_filepath.string()));
-  internal::add_path(absolute_filepath, current_header_files_);
+  current_header_files_.emplace(
+      internal::Path::CreateExistingPath(absolute_filepath));
 }
 
 void Target::AddHeader(const fs::path &relative_filename,

--- a/buildcc/lib/target/src/target/lib.cpp
+++ b/buildcc/lib/target/src/target/lib.cpp
@@ -38,7 +38,7 @@ void Target::AddLibDirAbsolute(const fs::path &absolute_lib_dir) {
 void Target::AddLibDep(const Target &lib_dep) {
   env::log_trace(name_, __FUNCTION__);
 
-  target_lib_deps_.insert(&lib_dep);
+  current_lib_deps_.user.insert(&lib_dep);
 }
 
 void Target::AddLibDep(const std::string &lib_dep) {

--- a/buildcc/lib/target/src/target/source.cpp
+++ b/buildcc/lib/target/src/target/source.cpp
@@ -33,7 +33,7 @@ void Target::AddSourceAbsolute(const fs::path &absolute_input_filepath,
 
   const fs::path absolute_source =
       fs::path(absolute_input_filepath).make_preferred();
-  internal::add_path(absolute_source, current_source_files_);
+  user_source_files_.insert(absolute_source);
 
   // Relate input source files with output object files
   const auto absolute_compiled_source =

--- a/buildcc/lib/target/src/target/source.cpp
+++ b/buildcc/lib/target/src/target/source.cpp
@@ -33,7 +33,7 @@ void Target::AddSourceAbsolute(const fs::path &absolute_input_filepath,
 
   const fs::path absolute_source =
       fs::path(absolute_input_filepath).make_preferred();
-  user_source_files_.insert(absolute_source);
+  current_source_files_.user.insert(absolute_source);
 
   // Relate input source files with output object files
   const auto absolute_compiled_source =
@@ -110,7 +110,8 @@ void Target::GlobSources(const fs::path &relative_to_target_path) {
 
 void Target::CompileSources(std::vector<fs::path> &compile_sources) {
   env::log_trace(name_, __FUNCTION__);
-  std::transform(current_source_files_.begin(), current_source_files_.end(),
+  std::transform(current_source_files_.internal.begin(),
+                 current_source_files_.internal.end(),
                  std::back_inserter(compile_sources),
                  [](const buildcc::internal::Path &p) -> fs::path {
                    return p.GetPathname();
@@ -125,13 +126,13 @@ void Target::RecompileSources(std::vector<fs::path> &compile_sources,
 
   // * Cannot find previous source in current source files
   const bool is_source_removed = internal::is_previous_paths_different(
-      previous_source_files, current_source_files_);
+      previous_source_files, current_source_files_.internal);
   if (is_source_removed) {
     dirty_ = true;
     SourceRemoved();
   }
 
-  for (const auto &current_file : current_source_files_) {
+  for (const auto &current_file : current_source_files_.internal) {
     const auto &current_source = current_file.GetPathname();
 
     // Find current_file in the loaded sources

--- a/buildcc/lib/target/src/target/target.cpp
+++ b/buildcc/lib/target/src/target/target.cpp
@@ -48,12 +48,10 @@ namespace buildcc::base {
 
 // PUBLIC
 void Target::AddCompileDependencyAbsolute(const fs::path &absolute_path) {
-  current_compile_dependencies_.emplace(
-      internal::Path::CreateExistingPath(absolute_path));
+  current_compile_dependencies_.user.insert(absolute_path);
 }
 void Target::AddLinkDependencyAbsolute(const fs::path &absolute_path) {
-  current_link_dependencies_.emplace(
-      internal::Path::CreateExistingPath(absolute_path));
+  current_link_dependencies_.user.insert(absolute_path);
 }
 
 void Target::AddCompileDependency(const fs::path &relative_path) {

--- a/buildcc/lib/target/src/target/target.cpp
+++ b/buildcc/lib/target/src/target/target.cpp
@@ -48,10 +48,12 @@ namespace buildcc::base {
 
 // PUBLIC
 void Target::AddCompileDependencyAbsolute(const fs::path &absolute_path) {
-  internal::add_path(absolute_path, current_compile_dependencies_);
+  current_compile_dependencies_.emplace(
+      internal::Path::CreateExistingPath(absolute_path));
 }
 void Target::AddLinkDependencyAbsolute(const fs::path &absolute_path) {
-  internal::add_path(absolute_path, current_link_dependencies_);
+  current_link_dependencies_.emplace(
+      internal::Path::CreateExistingPath(absolute_path));
 }
 
 void Target::AddCompileDependency(const fs::path &relative_path) {

--- a/buildcc/lib/target/src/target/target_storer.cpp
+++ b/buildcc/lib/target/src/target/target_storer.cpp
@@ -45,7 +45,7 @@ bool Target::Store() {
   auto fbs_target_type = CreateFbsTargetType(type_);
 
   auto fbs_source_files =
-      internal::CreateFbsVectorPath(builder, current_source_files_);
+      internal::CreateFbsVectorPath(builder, current_source_files_.internal);
   auto fbs_header_files =
       internal::CreateFbsVectorPath(builder, current_header_files_);
   auto fbs_lib_deps = internal::CreateFbsVectorPath(builder, current_lib_deps_);

--- a/buildcc/lib/target/src/target/target_storer.cpp
+++ b/buildcc/lib/target/src/target/target_storer.cpp
@@ -48,7 +48,8 @@ bool Target::Store() {
       internal::CreateFbsVectorPath(builder, current_source_files_.internal);
   auto fbs_header_files =
       internal::CreateFbsVectorPath(builder, current_header_files_.internal);
-  auto fbs_lib_deps = internal::CreateFbsVectorPath(builder, current_lib_deps_);
+  auto fbs_lib_deps =
+      internal::CreateFbsVectorPath(builder, current_lib_deps_.internal);
 
   auto fbs_external_lib_deps =
       internal::CreateFbsVectorString(builder, current_external_lib_deps_);

--- a/buildcc/lib/target/src/target/target_storer.cpp
+++ b/buildcc/lib/target/src/target/target_storer.cpp
@@ -47,7 +47,7 @@ bool Target::Store() {
   auto fbs_source_files =
       internal::CreateFbsVectorPath(builder, current_source_files_.internal);
   auto fbs_header_files =
-      internal::CreateFbsVectorPath(builder, current_header_files_);
+      internal::CreateFbsVectorPath(builder, current_header_files_.internal);
   auto fbs_lib_deps = internal::CreateFbsVectorPath(builder, current_lib_deps_);
 
   auto fbs_external_lib_deps =

--- a/buildcc/lib/target/src/target/target_storer.cpp
+++ b/buildcc/lib/target/src/target/target_storer.cpp
@@ -70,10 +70,10 @@ bool Target::Store() {
   auto fbs_link_flags =
       internal::CreateFbsVectorString(builder, current_link_flags_);
 
-  auto fbs_compile_dependencies =
-      internal::CreateFbsVectorPath(builder, current_compile_dependencies_);
-  auto fbs_link_dependencies =
-      internal::CreateFbsVectorPath(builder, current_link_dependencies_);
+  auto fbs_compile_dependencies = internal::CreateFbsVectorPath(
+      builder, current_compile_dependencies_.internal);
+  auto fbs_link_dependencies = internal::CreateFbsVectorPath(
+      builder, current_link_dependencies_.internal);
 
   auto fbs_target = fbs::CreateTargetDirect(
       builder, name_.c_str(), fbs_target_type, &fbs_source_files,

--- a/buildcc/lib/target/src/target/tasks.cpp
+++ b/buildcc/lib/target/src/target/tasks.cpp
@@ -38,7 +38,7 @@ void Target::CompileTask() {
   env::log_trace(name_, __FUNCTION__);
 
   compile_task_ = tf_.emplace([this](tf::Subflow &subflow) {
-    Convert();
+    ConvertForCompile();
 
     std::vector<fs::path> compile_sources;
     std::vector<fs::path> dummy_sources;
@@ -64,7 +64,10 @@ void Target::CompileTask() {
 
 void Target::LinkTask() {
   env::log_trace(name_, __FUNCTION__);
-  link_task_ = tf_.emplace([this]() { BuildLink(); });
+  link_task_ = tf_.emplace([this]() {
+    ConvertForLink();
+    BuildLink();
+  });
   link_task_.name(kLinkTaskName);
   link_task_.succeed(compile_task_);
 }

--- a/buildcc/lib/target/src/target/tasks.cpp
+++ b/buildcc/lib/target/src/target/tasks.cpp
@@ -38,6 +38,8 @@ void Target::CompileTask() {
   env::log_trace(name_, __FUNCTION__);
 
   compile_task_ = tf_.emplace([this](tf::Subflow &subflow) {
+    Convert();
+
     std::vector<fs::path> compile_sources;
     std::vector<fs::path> dummy_sources;
     BuildCompile(compile_sources, dummy_sources);

--- a/buildcc/lib/target/src/util/util.cpp
+++ b/buildcc/lib/target/src/util/util.cpp
@@ -32,18 +32,6 @@ bool is_previous_paths_different(const path_unordered_set &previous_paths,
                      });
 }
 
-// Additions
-bool add_path(const fs::path &path, path_unordered_set &stored_paths) {
-  auto current_file = buildcc::internal::Path::CreateExistingPath(path);
-
-  // TODO, Note, we might not require this check
-  env::assert_fatal(stored_paths.find(current_file) == stored_paths.end(),
-                    fmt::format("{} duplicate found", path.string()));
-
-  auto [_, added] = stored_paths.insert(current_file);
-  return added;
-}
-
 // Aggregates
 
 std::string aggregate(const std::vector<std::string> &list) {

--- a/buildcc/lib/target/test/target/test_generator.cpp
+++ b/buildcc/lib/target/test/target/test_generator.cpp
@@ -30,19 +30,17 @@ TEST(GeneratorTestGroup, Generator_AddInfo) {
   fs::create_directories(TEST_BUILD_DIR);
 
   buildcc::base::Generator generator("custom_file_generator", TEST_BUILD_DIR);
-  generator.AddGenInfo(buildcc::base::UserGenInfo(
-      "gcc_1",
-      {
-          "data/dummy_main.c",
-      },
-      {TEST_BUILD_DIR / "dummy_main.exe"},
-      {"gcc -o intermediate/generator/AddInfo/dummy_main.exe "
-       "data/dummy_main.c"},
-      true));
+  generator.AddGenInfo("gcc_1",
+                       {
+                           "data/dummy_main.c",
+                       },
+                       {TEST_BUILD_DIR / "dummy_main.exe"},
+                       {"gcc -o intermediate/generator/AddInfo/dummy_main.exe "
+                        "data/dummy_main.c"},
+                       true);
 
   CHECK_THROWS(buildcc::env::assert_exception,
-               generator.AddGenInfo(
-                   buildcc::base::UserGenInfo("gcc_1", {}, {}, {}, true)));
+               generator.AddGenInfo("gcc_1", {}, {}, {}, true));
 }
 
 TEST(GeneratorTestGroup, Generator_Build) {
@@ -50,15 +48,14 @@ TEST(GeneratorTestGroup, Generator_Build) {
   fs::create_directories(TEST_BUILD_DIR);
 
   buildcc::base::Generator generator("custom_file_generator", TEST_BUILD_DIR);
-  generator.AddGenInfo(buildcc::base::UserGenInfo(
-      "gcc_1",
-      {
-          "data/dummy_main.c",
-      },
-      {TEST_BUILD_DIR / "dummy_main.exe"},
-      {"gcc -o intermediate/generator/Build/dummy_main.exe "
-       "data/dummy_main.c"},
-      true));
+  generator.AddGenInfo("gcc_1",
+                       {
+                           "data/dummy_main.c",
+                       },
+                       {TEST_BUILD_DIR / "dummy_main.exe"},
+                       {"gcc -o intermediate/generator/Build/dummy_main.exe "
+                        "data/dummy_main.c"},
+                       true);
 
   buildcc::m::CommandExpect_Execute(1, true);
   generator.Build();
@@ -72,7 +69,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild) {
 
   {
     buildcc::base::Generator generator("custom_file_generator", TEST_BUILD_DIR);
-    generator.AddGenInfo(buildcc::base::UserGenInfo(
+    generator.AddGenInfo(
         "gcc_1",
         {
             "data/dummy_main.c",
@@ -80,7 +77,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild) {
         {TEST_BUILD_DIR / "dummy_main.exe"},
         {"gcc -o intermediate/generator/Rebuild/dummy_main.exe "
          "data/dummy_main.c"},
-        true));
+        true);
 
     buildcc::m::CommandExpect_Execute(1, true);
     generator.Build();
@@ -88,7 +85,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild) {
 
   {
     buildcc::base::Generator generator("custom_file_generator", TEST_BUILD_DIR);
-    generator.AddGenInfo(buildcc::base::UserGenInfo(
+    generator.AddGenInfo(
         "gcc_1",
         {
             "data/dummy_main.c",
@@ -96,7 +93,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild) {
         {TEST_BUILD_DIR / "dummy_main.exe"},
         {"gcc -o intermediate/generator/Rebuild/dummy_main.exe "
          "data/dummy_main.c"},
-        true));
+        true);
 
     generator.Build();
   }
@@ -110,7 +107,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_PreviousNotFound) {
 
   {
     buildcc::base::Generator generator("custom_file_generator", TEST_BUILD_DIR);
-    generator.AddGenInfo(buildcc::base::UserGenInfo(
+    generator.AddGenInfo(
         "gcc_1",
         {
             "data/dummy_main.c",
@@ -119,7 +116,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_PreviousNotFound) {
         {"gcc -o "
          "intermediate/generator/Rebuild_PreviousNotFound/dummy_main.exe "
          "data/dummy_main.c"},
-        true));
+        true);
 
     buildcc::m::CommandExpect_Execute(1, true);
     generator.Build();
@@ -127,7 +124,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_PreviousNotFound) {
 
   {
     buildcc::base::Generator generator("custom_file_generator", TEST_BUILD_DIR);
-    generator.AddGenInfo(buildcc::base::UserGenInfo(
+    generator.AddGenInfo(
         "gcc_1",
         {
             "data/dummy_main.c",
@@ -136,10 +133,10 @@ TEST(GeneratorTestGroup, Generator_Rebuild_PreviousNotFound) {
         {"gcc -o "
          "intermediate/generator/Rebuild_PreviousNotFound/dummy_main.exe "
          "data/dummy_main.c"},
-        true));
+        true);
 
     // Current Info is NEWER than old
-    generator.AddGenInfo(buildcc::base::UserGenInfo(
+    generator.AddGenInfo(
         "gcc_2",
         {
             "data/dummy_main.c",
@@ -148,7 +145,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_PreviousNotFound) {
         {"gcc -o "
          "intermediate/generator/Rebuild_PreviousNotFound/dummy_main.exe "
          "data/dummy_main.c"},
-        true));
+        true);
 
     buildcc::m::CommandExpect_Execute(1, true);
     generator.Build();
@@ -163,7 +160,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_Inputs) {
 
   {
     buildcc::base::Generator generator("custom_file_generator", TEST_BUILD_DIR);
-    generator.AddGenInfo(buildcc::base::UserGenInfo(
+    generator.AddGenInfo(
         "gcc_1",
         {
             "data/dummy_main.c",
@@ -171,7 +168,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_Inputs) {
         {TEST_BUILD_DIR / "dummy_main.exe"},
         {"gcc -o intermediate/generator/Rebuild_Inputs/dummy_main.exe "
          "data/dummy_main.c"},
-        true));
+        true);
 
     buildcc::m::CommandExpect_Execute(1, true);
     generator.Build();
@@ -179,7 +176,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_Inputs) {
 
   {
     buildcc::base::Generator generator("custom_file_generator", TEST_BUILD_DIR);
-    generator.AddGenInfo(buildcc::base::UserGenInfo(
+    generator.AddGenInfo(
         "gcc_1",
         {
             "data/dummy_main.c",
@@ -188,7 +185,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_Inputs) {
         {TEST_BUILD_DIR / "dummy_main.exe"},
         {"gcc -o intermediate/generator/Rebuild_Inputs/dummy_main.exe "
          "data/dummy_main.c"},
-        true));
+        true);
 
     buildcc::base::m::GeneratorExpect_InputAdded(1, &generator);
     buildcc::m::CommandExpect_Execute(1, true);
@@ -197,7 +194,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_Inputs) {
 
   {
     buildcc::base::Generator generator("custom_file_generator", TEST_BUILD_DIR);
-    generator.AddGenInfo(buildcc::base::UserGenInfo(
+    generator.AddGenInfo(
         "gcc_1",
         {
             "data/new_source.cpp",
@@ -205,7 +202,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_Inputs) {
         {TEST_BUILD_DIR / "dummy_main.exe"},
         {"gcc -o intermediate/generator/Rebuild_Inputs/dummy_main.exe "
          "data/dummy_main.c"},
-        true));
+        true);
 
     buildcc::base::m::GeneratorExpect_InputRemoved(1, &generator);
     buildcc::m::CommandExpect_Execute(1, true);
@@ -218,7 +215,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_Inputs) {
 
   {
     buildcc::base::Generator generator("custom_file_generator", TEST_BUILD_DIR);
-    generator.AddGenInfo(buildcc::base::UserGenInfo(
+    generator.AddGenInfo(
         "gcc_1",
         {
             "data/new_source.cpp",
@@ -226,7 +223,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_Inputs) {
         {TEST_BUILD_DIR / "dummy_main.exe"},
         {"gcc -o intermediate/generator/Rebuild_Inputs/dummy_main.exe "
          "data/dummy_main.c"},
-        true));
+        true);
 
     buildcc::base::m::GeneratorExpect_InputUpdated(1, &generator);
     buildcc::m::CommandExpect_Execute(1, true);
@@ -242,7 +239,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_Outputs) {
 
   {
     buildcc::base::Generator generator("custom_file_generator", TEST_BUILD_DIR);
-    generator.AddGenInfo(buildcc::base::UserGenInfo(
+    generator.AddGenInfo(
         "gcc_1",
         {
             "data/dummy_main.c",
@@ -253,7 +250,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_Outputs) {
         },
         {"gcc -o intermediate/generator/Rebuild_Outputs/dummy_main.exe "
          "data/dummy_main.c"},
-        true));
+        true);
 
     buildcc::m::CommandExpect_Execute(1, true);
     generator.Build();
@@ -261,7 +258,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_Outputs) {
 
   {
     buildcc::base::Generator generator("custom_file_generator", TEST_BUILD_DIR);
-    generator.AddGenInfo(buildcc::base::UserGenInfo(
+    generator.AddGenInfo(
         "gcc_1",
         {
             "data/dummy_main.c",
@@ -269,7 +266,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_Outputs) {
         {TEST_BUILD_DIR / "dummy_main.exe"},
         {"gcc -o intermediate/generator/Rebuild_Outputs/dummy_main.exe "
          "data/dummy_main.c"},
-        true));
+        true);
 
     buildcc::base::m::GeneratorExpect_OutputChanged(1, &generator);
     buildcc::m::CommandExpect_Execute(1, true);
@@ -285,7 +282,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_Commands) {
 
   {
     buildcc::base::Generator generator("custom_file_generator", TEST_BUILD_DIR);
-    generator.AddGenInfo(buildcc::base::UserGenInfo(
+    generator.AddGenInfo(
         "gcc_1",
         {
             "data/dummy_main.c",
@@ -296,7 +293,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_Commands) {
         },
         {"gcc -o intermediate/generator/Rebuild_Commands/dummy_main.exe "
          "data/dummy_main.c"},
-        true));
+        true);
 
     buildcc::m::CommandExpect_Execute(1, true);
     generator.Build();
@@ -304,7 +301,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_Commands) {
 
   {
     buildcc::base::Generator generator("custom_file_generator", TEST_BUILD_DIR);
-    generator.AddGenInfo(buildcc::base::UserGenInfo(
+    generator.AddGenInfo(
         "gcc_1",
         {
             "data/dummy_main.c",
@@ -319,7 +316,7 @@ TEST(GeneratorTestGroup, Generator_Rebuild_Commands) {
             "gcc -o intermediate/generator/Rebuild_Commands/dummy_main.exe "
             "intermediate/generator/Rebuild_Commands/dummy_main.o",
         },
-        true));
+        true);
 
     buildcc::base::m::GeneratorExpect_CommandChanged(1, &generator);
     buildcc::m::CommandExpect_Execute(1, true);
@@ -336,7 +333,7 @@ TEST(GeneratorTestGroup, Generator_DoubleDependency) {
   fs::create_directories(TEST_BUILD_DIR);
 
   buildcc::base::Generator ogen("custom_object_generator", TEST_BUILD_DIR);
-  ogen.AddGenInfo(buildcc::base::UserGenInfo(
+  ogen.AddGenInfo(
       "gcc_1",
       {
           "data/dummy_main.c",
@@ -344,7 +341,7 @@ TEST(GeneratorTestGroup, Generator_DoubleDependency) {
       {TEST_BUILD_DIR / "dummy_main.o"},
       {"gcc -c -o intermediate/generator/DoubleDependency/dummy_main.o "
        "data/dummy_main.c"},
-      true));
+      true);
 
   buildcc::m::CommandExpect_Execute(1, true);
   ogen.Build();
@@ -354,7 +351,7 @@ TEST(GeneratorTestGroup, Generator_DoubleDependency) {
                          false);
 
   buildcc::base::Generator egen("custom_exe_generator", TEST_BUILD_DIR);
-  egen.AddGenInfo(buildcc::base::UserGenInfo(
+  egen.AddGenInfo(
       "gcc_1",
       {
           TEST_BUILD_DIR / "dummy_main.o",
@@ -362,7 +359,7 @@ TEST(GeneratorTestGroup, Generator_DoubleDependency) {
       {TEST_BUILD_DIR / "dummy_main.o"},
       {"gcc -o intermediate/generator/DoubleDependency/dummy_main.exe "
        "intermediate/generator/DoubleDependency/dummy_main.o"},
-      true));
+      true);
 
   buildcc::m::CommandExpect_Execute(1, true);
   egen.Build();

--- a/buildcc/lib/target/test/target/test_target_source.cpp
+++ b/buildcc/lib/target/test/target/test_target_source.cpp
@@ -68,10 +68,6 @@ TEST(TargetTestSourceGroup, Target_AddSource) {
   buildcc::base::Target simple(NAME, buildcc::base::TargetType::Executable, gcc,
                                "data");
   simple.AddSource(DUMMY_MAIN);
-  // File does not exist
-  CHECK_THROWS(std::exception, simple.AddSource(NO_FILE));
-  // Duplicate file added
-  CHECK_THROWS(std::exception, simple.AddSource(DUMMY_MAIN));
 }
 
 TEST(TargetTestSourceGroup, Target_GlobSource) {

--- a/buildcc/plugins/src/clang_compile_commands.cpp
+++ b/buildcc/plugins/src/clang_compile_commands.cpp
@@ -61,7 +61,7 @@ R"({{
       // DONE, Get source list name
       // DONE, Get std::vector<std::string> CompileCommand
       // DONE, Get intermediate directory from env
-      std::string file = f.GetPathname().string();
+      std::string file = f.string();
       std::string command = t->CompileCommand(file);
       std::string directory = env::get_project_build_dir().string();
 


### PR DESCRIPTION
We cannot guarantee that file paths would be present when the user is defining the build. Checking the timestamp when the user is adding a file to a Generator/Target is potentially error-prone.

## Why?
The input to a Generator / Target might also be generated!
We must only verify the File timestamp AFTER dependent Generator(s) / Target(s) have been built