### PR TITLE
Args update

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Build C, C++ and ASM files in C++
 - Third Party Libraries (See License below)
   - Flatbuffers v2.0.0
   - Taskflow v3.1.0
-  - CLI11 v1.9.1
+  - CLI11 v2.1.0
   - Tiny Process Library v2.0.4
   - fmt v8.0.1
   - spdlog v1.9.2

--- a/buildcc/lib/args/CMakeLists.txt
+++ b/buildcc/lib/args/CMakeLists.txt
@@ -1,6 +1,39 @@
 # Args test
 if (${TESTING})
-# TODO, Add for unit testing and mocking
+add_library(mock_args
+    src/args.cpp
+    # src/register.cpp
+)
+target_include_directories(mock_args PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+target_compile_options(mock_args PUBLIC 
+    ${TEST_COMPILE_FLAGS} ${BUILD_COMPILE_FLAGS}
+)
+target_link_options(mock_args PUBLIC 
+    ${TEST_LINK_FLAGS} ${BUILD_LINK_FLAGS}
+)
+target_link_libraries(mock_args PUBLIC 
+    CLI11::CLI11
+
+    mock_target
+
+    CppUTest
+    CppUTestExt
+    gcov
+)
+
+# Tests
+add_executable(test_args
+    test/test_args.cpp
+)
+target_link_libraries(test_args PRIVATE
+    mock_args
+)
+
+add_test(NAME test_args COMMAND test_args
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test
+)
 endif()
 
 set(ARGS_SRCS

--- a/buildcc/lib/args/CMakeLists.txt
+++ b/buildcc/lib/args/CMakeLists.txt
@@ -2,6 +2,7 @@
 if (${TESTING})
 add_library(mock_args
     src/args.cpp
+    mock/parse.cpp
     # src/register.cpp
 )
 target_include_directories(mock_args PUBLIC
@@ -38,6 +39,7 @@ endif()
 
 set(ARGS_SRCS
     src/args.cpp
+    src/parse.cpp
     src/register.cpp
     include/args/args.h
     include/args/register.h

--- a/buildcc/lib/args/include/args/args.h
+++ b/buildcc/lib/args/include/args/args.h
@@ -103,10 +103,6 @@ public:
   const fs::path &GetProjectRootDir() const { return project_root_dir_; }
   const fs::path &GetProjectBuildDir() const { return project_build_dir_; }
 
-  // TODO, Remove custom toolchain support
-  const ToolchainState &GetGccState() const { return gcc_state_; }
-  const ToolchainState &GetMsvcState() const { return msvc_state_; }
-
 private:
   void Initialize();
   void RootArgs();
@@ -117,10 +113,6 @@ private:
   env::LogLevel loglevel_{env::LogLevel::Info};
   fs::path project_root_dir_{""};
   fs::path project_build_dir_{"_internal"};
-
-  // TODO, Remove
-  ToolchainState gcc_state_{false, false};
-  ToolchainState msvc_state_{false, false};
 
   // Internal
   CLI::App app_{"BuildCC buildsystem"};

--- a/buildcc/lib/args/include/args/args.h
+++ b/buildcc/lib/args/include/args/args.h
@@ -41,6 +41,18 @@ public:
   struct ToolchainArg {
     ToolchainArg(){};
 
+    ToolchainArg(base::Toolchain::Id initial_id,
+                 const std::string &initial_name,
+                 const std::string &initial_asm_compiler,
+                 const std::string &initial_c_compiler,
+                 const std::string &initial_cpp_compiler,
+                 const std::string &initial_archiver,
+                 const std::string &initial_linker)
+        : id(initial_id), name(initial_name),
+          asm_compiler(initial_asm_compiler), c_compiler(initial_c_compiler),
+          cpp_compiler(initial_cpp_compiler), archiver(initial_archiver),
+          linker(initial_linker) {}
+
     base::Toolchain ConstructToolchain() {
       base::Toolchain toolchain(id, name, asm_compiler, c_compiler,
                                 cpp_compiler, archiver, linker);
@@ -97,8 +109,6 @@ private:
   void Initialize();
 
   void RootArgs();
-  void CommonToolchainArgs();
-  void CommonTargetArgs();
 
   CLI::App *AddToolchain(const std::string &name,
                          const std::string &description,
@@ -110,21 +120,6 @@ private:
 
   bool clean_{false};
   env::LogLevel loglevel_{env::LogLevel::Info};
-  const std::map<std::string, env::LogLevel> loglevel_map_{
-      {"Trace", env::LogLevel::Trace},
-      {"Debug", env::LogLevel::Debug},
-      {"Info", env::LogLevel::Info},
-      {"Warning", env::LogLevel::Warning},
-      {"Critical", env::LogLevel::Critical},
-  };
-
-  const std::map<std::string, base::Toolchain::Id> toolchain_id_map_{
-      {"Gcc", base::Toolchain::Id::Gcc},
-      {"Msvc", base::Toolchain::Id::Msvc},
-      {"Clang", base::Toolchain::Id::Clang},
-      {"Custom", base::Toolchain::Id::Custom},
-      {"Undefined", base::Toolchain::Id::Undefined},
-  };
 
   // directory
   fs::path project_root_dir_{""};

--- a/buildcc/lib/args/include/args/args.h
+++ b/buildcc/lib/args/include/args/args.h
@@ -68,7 +68,7 @@ public:
   Args() { Initialize(); }
   Args(const Args &) = delete;
 
-  void Parse(int argc, char **argv);
+  void Parse(int argc, const char *const *argv);
 
   // TODO, Check if these are necessary
   CLI::App &Ref() { return app_; }

--- a/buildcc/lib/args/include/args/args.h
+++ b/buildcc/lib/args/include/args/args.h
@@ -38,6 +38,9 @@ public:
     bool test{false};
   };
 
+  // TODO, Rename to Toolchain
+  // TODO, Put ToolchainState into Args::Toolchain
+  // TODO, Add operator() overload and remove ConstructToolchain
   struct ToolchainArg {
     ToolchainArg(){};
 
@@ -87,11 +90,11 @@ public:
   const CLI::App &ConstRef() const { return app_; }
 
   // Setters
-  void AddCustomToolchain(const std::string &name,
-                          const std::string &description, ToolchainArg &out,
-                          const ToolchainArg &initial = ToolchainArg());
-  void AddCustomTarget(const std::string &name, const std::string &description,
-                       TargetArg &out, const TargetArg &initial = TargetArg());
+  void AddToolchain(const std::string &name, const std::string &description,
+                    ToolchainArg &out,
+                    const ToolchainArg &initial = ToolchainArg());
+  void AddTarget(const std::string &name, const std::string &description,
+                 TargetArg &out, const TargetArg &initial = TargetArg());
 
   // Getters
   bool Clean() const { return clean_; }
@@ -100,35 +103,27 @@ public:
   const fs::path &GetProjectRootDir() const { return project_root_dir_; }
   const fs::path &GetProjectBuildDir() const { return project_build_dir_; }
 
-  // Arg supported toolchains
-  // TODO, Add more as needed
+  // TODO, Remove custom toolchain support
   const ToolchainState &GetGccState() const { return gcc_state_; }
   const ToolchainState &GetMsvcState() const { return msvc_state_; }
 
 private:
   void Initialize();
-
   void RootArgs();
 
-  CLI::App *AddToolchain(const std::string &name,
-                         const std::string &description,
-                         const std::string &group,
-                         ToolchainState &toolchain_state);
-
 private:
-  CLI::App app_{"BuildCC buildsystem"};
-
+  // Required parameters
   bool clean_{false};
   env::LogLevel loglevel_{env::LogLevel::Info};
-
-  // directory
   fs::path project_root_dir_{""};
   fs::path project_build_dir_{"_internal"};
 
+  // TODO, Remove
   ToolchainState gcc_state_{false, false};
   ToolchainState msvc_state_{false, false};
 
   // Internal
+  CLI::App app_{"BuildCC buildsystem"};
   CLI::App *toolchain_{nullptr};
   CLI::App *target_{nullptr};
 };

--- a/buildcc/lib/args/mock/parse.cpp
+++ b/buildcc/lib/args/mock/parse.cpp
@@ -1,0 +1,15 @@
+#include "args/args.h"
+
+#include "env/assert_fatal.h"
+
+namespace buildcc {
+
+void Args::Parse(int argc, const char *const *argv) {
+  try {
+    app_.parse(argc, argv);
+  } catch (const CLI::ParseError &e) {
+    env::assert_fatal<false>(e.what());
+  }
+}
+
+} // namespace buildcc

--- a/buildcc/lib/args/src/args.cpp
+++ b/buildcc/lib/args/src/args.cpp
@@ -51,6 +51,23 @@ constexpr const char *const kToolchainDesc = "Select Toolchain";
 constexpr const char *const kTargetSubcommand = "target";
 constexpr const char *const kTargetDesc = "Select Target";
 
+const std::unordered_map<const char *, buildcc::env::LogLevel> kLogLevelMap{
+    {"trace", buildcc::env::LogLevel::Trace},
+    {"debug", buildcc::env::LogLevel::Debug},
+    {"info", buildcc::env::LogLevel::Info},
+    {"warning", buildcc::env::LogLevel::Warning},
+    {"critical", buildcc::env::LogLevel::Critical},
+};
+
+const std::unordered_map<const char *, buildcc::base::Toolchain::Id>
+    kToolchainIdMap{
+        {"gcc", buildcc::base::Toolchain::Id::Gcc},
+        {"msvc", buildcc::base::Toolchain::Id::Msvc},
+        {"clang", buildcc::base::Toolchain::Id::Clang},
+        {"custom", buildcc::base::Toolchain::Id::Custom},
+        {"undefined", buildcc::base::Toolchain::Id::Undefined},
+    };
+
 } // namespace
 
 namespace buildcc {
@@ -60,15 +77,8 @@ void Args::AddCustomToolchain(const std::string &name,
                               const ToolchainArg &initial) {
   CLI::App *t_user = AddToolchain(name, description, "Custom", out.state);
 
-  const std::unordered_map<std::string, base::Toolchain::Id> toolchain_id_map_{
-      {"gcc", base::Toolchain::Id::Gcc},
-      {"msvc", base::Toolchain::Id::Msvc},
-      {"clang", base::Toolchain::Id::Clang},
-      {"custom", base::Toolchain::Id::Custom},
-      {"undefined", base::Toolchain::Id::Undefined},
-  };
   t_user->add_option("--id", out.id, "Toolchain ID settings")
-      ->transform(CLI::CheckedTransformer(toolchain_id_map_, CLI::ignore_case))
+      ->transform(CLI::CheckedTransformer(kToolchainIdMap, CLI::ignore_case))
       ->default_val(initial.id);
   t_user->add_option("--name", out.name)->default_val(initial.name);
   t_user->add_option("--asm_compiler", out.asm_compiler)
@@ -106,16 +116,10 @@ void Args::RootArgs() {
   app_.set_config(kConfigFlag, "", kConfigDesc)->expected(kMinFiles, kMaxFiles);
 
   // Root flags
-  const std::unordered_map<std::string, env::LogLevel> loglevel_map_{
-      {"trace", env::LogLevel::Trace},
-      {"debug", env::LogLevel::Debug},
-      {"info", env::LogLevel::Info},
-      {"warning", env::LogLevel::Warning},
-      {"critical", env::LogLevel::Critical},
-  };
+
   app_.add_flag(kCleanFlag, clean_, kCleanDesc)->group(kRootGroup);
   app_.add_option(kLoglevelFlag, loglevel_, kLoglevelDesc)
-      ->transform(CLI::CheckedTransformer(loglevel_map_, CLI::ignore_case))
+      ->transform(CLI::CheckedTransformer(kLogLevelMap, CLI::ignore_case))
       ->group(kRootGroup);
 
   // Dir flags

--- a/buildcc/lib/args/src/args.cpp
+++ b/buildcc/lib/args/src/args.cpp
@@ -61,6 +61,9 @@ constexpr const char *const kToolchainLinkerParam = "--linker";
 constexpr const char *const kTargetSubcommand = "target";
 constexpr const char *const kTargetDesc = "Select Target";
 
+constexpr const char *const kTargetCompileCommandParam = "--compile_command";
+constexpr const char *const kTargetLinkCommandParam = "--link_command";
+
 const std::unordered_map<const char *, buildcc::env::LogLevel> kLogLevelMap{
     {"trace", buildcc::env::LogLevel::Trace},
     {"debug", buildcc::env::LogLevel::Debug},
@@ -109,9 +112,9 @@ void Args::AddTarget(const std::string &name, const std::string &description,
                      TargetArg &out, const TargetArg &initial) {
   CLI::App *target_user =
       target_->add_subcommand(name, description)->group("Custom");
-  target_user->add_option("--compile_command", out.compile_command)
+  target_user->add_option(kTargetCompileCommandParam, out.compile_command)
       ->default_val(initial.compile_command);
-  target_user->add_option("--link_command", out.link_command)
+  target_user->add_option(kTargetLinkCommandParam, out.link_command)
       ->default_val(initial.link_command);
 }
 

--- a/buildcc/lib/args/src/args.cpp
+++ b/buildcc/lib/args/src/args.cpp
@@ -16,6 +16,13 @@
 
 #include "args/args.h"
 
+namespace {
+
+constexpr int kMinFiles = 0;
+constexpr int kMaxFiles = INT_MAX;
+
+} // namespace
+
 namespace buildcc {
 
 void Args::AddCustomToolchain(const std::string &name,
@@ -55,10 +62,8 @@ void Args::Initialize() { RootArgs(); }
 void Args::RootArgs() {
   app_.set_help_all_flag("--help-all", "Expand individual options");
 
-  // TODO, Currently only expects 1
-  // From CLI11 2.0 onwards multiple configuration files can be added, increase
-  // this limit
-  app_.set_config("--config", "", "Read a <config>.toml file")->expected(1);
+  app_.set_config("--config", "", "Read a <config>.toml file")
+      ->expected(kMinFiles, kMaxFiles);
 
   // Root flags
   app_.add_flag("--clean", clean_, "Clean artifacts")->group("Root");

--- a/buildcc/lib/args/src/args.cpp
+++ b/buildcc/lib/args/src/args.cpp
@@ -47,6 +47,8 @@ constexpr const char *const kBuildDirDesc =
 // Subcommands
 constexpr const char *const kToolchainSubcommand = "toolchain";
 constexpr const char *const kToolchainDesc = "Select Toolchain";
+constexpr const char *const kToolchainGroup = "Supported Toolchains";
+constexpr const char *const kToolchainIdDesc = "Toolchain ID settings";
 
 constexpr const char *const kToolchainBuildParam = "--build";
 constexpr const char *const kToolchainTestParam = "--test";
@@ -60,6 +62,7 @@ constexpr const char *const kToolchainLinkerParam = "--linker";
 
 constexpr const char *const kTargetSubcommand = "target";
 constexpr const char *const kTargetDesc = "Select Target";
+constexpr const char *const kTargetGroup = "Custom Target";
 
 constexpr const char *const kTargetCompileCommandParam = "--compile_command";
 constexpr const char *const kTargetLinkCommandParam = "--link_command";
@@ -87,12 +90,12 @@ namespace buildcc {
 
 void Args::AddToolchain(const std::string &name, const std::string &description,
                         ToolchainArg &out, const ToolchainArg &initial) {
-  CLI::App *t_user = toolchain_->add_subcommand(name, description)
-                         ->group("Supported Toolchains");
+  CLI::App *t_user =
+      toolchain_->add_subcommand(name, description)->group(kToolchainGroup);
   t_user->add_flag(kToolchainBuildParam, out.state.build);
   t_user->add_flag(kToolchainTestParam, out.state.test);
 
-  t_user->add_option(kToolchainIdParam, out.id, "Toolchain ID settings")
+  t_user->add_option(kToolchainIdParam, out.id, kToolchainIdDesc)
       ->transform(CLI::CheckedTransformer(kToolchainIdMap, CLI::ignore_case))
       ->default_val(initial.id);
   t_user->add_option(kToolchainNameParam, out.name)->default_val(initial.name);
@@ -111,7 +114,7 @@ void Args::AddToolchain(const std::string &name, const std::string &description,
 void Args::AddTarget(const std::string &name, const std::string &description,
                      TargetArg &out, const TargetArg &initial) {
   CLI::App *target_user =
-      target_->add_subcommand(name, description)->group("Custom");
+      target_->add_subcommand(name, description)->group(kTargetGroup);
   target_user->add_option(kTargetCompileCommandParam, out.compile_command)
       ->default_val(initial.compile_command);
   target_user->add_option(kTargetLinkCommandParam, out.link_command)

--- a/buildcc/lib/args/src/args.cpp
+++ b/buildcc/lib/args/src/args.cpp
@@ -22,25 +22,25 @@ namespace {
 constexpr const char *const kRootGroup = "Root";
 
 // Options & Flags
-constexpr const char *const kHelpAllFlag = "--help-all";
+constexpr const char *const kHelpAllParam = "--help-all";
 constexpr const char *const kHelpAllDesc = "Expand individual options.";
 
-constexpr const char *const kConfigFlag = "--config";
+constexpr const char *const kConfigParam = "--config";
 constexpr const char *const kConfigDesc = "Read <config>.toml files.";
 constexpr int kMinFiles = 0;
 constexpr int kMaxFiles = 10;
 
-constexpr const char *const kCleanFlag = "--clean";
+constexpr const char *const kCleanParam = "--clean";
 constexpr const char *const kCleanDesc = "Clean artifacts";
 
-constexpr const char *const kLoglevelFlag = "--loglevel";
+constexpr const char *const kLoglevelParam = "--loglevel";
 constexpr const char *const kLoglevelDesc = "LogLevel settings";
 
-constexpr const char *const kRootDirFlag = "--root_dir";
+constexpr const char *const kRootDirParam = "--root_dir";
 constexpr const char *const kRootDirDesc =
     "Project root directory (relative to current directory)";
 
-constexpr const char *const kBuildDirFlag = "--build_dir";
+constexpr const char *const kBuildDirParam = "--build_dir";
 constexpr const char *const kBuildDirDesc =
     "Project build dir (relative to current directory)";
 
@@ -48,15 +48,15 @@ constexpr const char *const kBuildDirDesc =
 constexpr const char *const kToolchainSubcommand = "toolchain";
 constexpr const char *const kToolchainDesc = "Select Toolchain";
 
-constexpr const char *const kToolchainBuildFlag = "--build";
-constexpr const char *const kToolchainTestFlag = "--test";
-constexpr const char *const kToolchainIdOption = "--id";
-constexpr const char *const kToolchainNameOption = "--name";
-constexpr const char *const kToolchainAsmCompilerOption = "--asm_compiler";
-constexpr const char *const kToolchainCCompilerOption = "--c_compiler";
-constexpr const char *const kToolchainCppCompilerOption = "--cpp_compiler";
-constexpr const char *const kToolchainArchiverOption = "--archiver";
-constexpr const char *const kToolchainLinkerOption = "--linker";
+constexpr const char *const kToolchainBuildParam = "--build";
+constexpr const char *const kToolchainTestParam = "--test";
+constexpr const char *const kToolchainIdParam = "--id";
+constexpr const char *const kToolchainNameParam = "--name";
+constexpr const char *const kToolchainAsmCompilerParam = "--asm_compiler";
+constexpr const char *const kToolchainCCompilerParam = "--c_compiler";
+constexpr const char *const kToolchainCppCompilerParam = "--cpp_compiler";
+constexpr const char *const kToolchainArchiverParam = "--archiver";
+constexpr const char *const kToolchainLinkerParam = "--linker";
 
 constexpr const char *const kTargetSubcommand = "target";
 constexpr const char *const kTargetDesc = "Select Target";
@@ -87,19 +87,19 @@ void Args::AddCustomToolchain(const std::string &name,
                               const ToolchainArg &initial) {
   CLI::App *t_user = AddToolchain(name, description, "Custom", out.state);
 
-  t_user->add_option(kToolchainIdOption, out.id, "Toolchain ID settings")
+  t_user->add_option(kToolchainIdParam, out.id, "Toolchain ID settings")
       ->transform(CLI::CheckedTransformer(kToolchainIdMap, CLI::ignore_case))
       ->default_val(initial.id);
-  t_user->add_option(kToolchainNameOption, out.name)->default_val(initial.name);
-  t_user->add_option(kToolchainAsmCompilerOption, out.asm_compiler)
+  t_user->add_option(kToolchainNameParam, out.name)->default_val(initial.name);
+  t_user->add_option(kToolchainAsmCompilerParam, out.asm_compiler)
       ->default_val(initial.asm_compiler);
-  t_user->add_option(kToolchainCCompilerOption, out.c_compiler)
+  t_user->add_option(kToolchainCCompilerParam, out.c_compiler)
       ->default_val(initial.c_compiler);
-  t_user->add_option(kToolchainCppCompilerOption, out.cpp_compiler)
+  t_user->add_option(kToolchainCppCompilerParam, out.cpp_compiler)
       ->default_val(initial.cpp_compiler);
-  t_user->add_option(kToolchainArchiverOption, out.archiver)
+  t_user->add_option(kToolchainArchiverParam, out.archiver)
       ->default_val(initial.archiver);
-  t_user->add_option(kToolchainLinkerOption, out.linker)
+  t_user->add_option(kToolchainLinkerParam, out.linker)
       ->default_val(initial.linker);
 }
 
@@ -123,22 +123,23 @@ void Args::Initialize() {
 }
 
 void Args::RootArgs() {
-  app_.set_help_all_flag(kHelpAllFlag, kHelpAllDesc);
+  app_.set_help_all_flag(kHelpAllParam, kHelpAllDesc);
 
-  app_.set_config(kConfigFlag, "", kConfigDesc)->expected(kMinFiles, kMaxFiles);
+  app_.set_config(kConfigParam, "", kConfigDesc)
+      ->expected(kMinFiles, kMaxFiles);
 
   // Root flags
 
-  app_.add_flag(kCleanFlag, clean_, kCleanDesc)->group(kRootGroup);
-  app_.add_option(kLoglevelFlag, loglevel_, kLoglevelDesc)
+  app_.add_flag(kCleanParam, clean_, kCleanDesc)->group(kRootGroup);
+  app_.add_option(kLoglevelParam, loglevel_, kLoglevelDesc)
       ->transform(CLI::CheckedTransformer(kLogLevelMap, CLI::ignore_case))
       ->group(kRootGroup);
 
   // Dir flags
-  app_.add_option(kRootDirFlag, project_root_dir_, kRootDirDesc)
+  app_.add_option(kRootDirParam, project_root_dir_, kRootDirDesc)
       ->required()
       ->group(kRootGroup);
-  app_.add_option(kBuildDirFlag, project_build_dir_, kBuildDirDesc)
+  app_.add_option(kBuildDirParam, project_build_dir_, kBuildDirDesc)
       ->required()
       ->group(kRootGroup);
 }
@@ -149,8 +150,8 @@ CLI::App *Args::AddToolchain(const std::string &name,
                              ToolchainState &toolchain_state) {
   CLI::App *t_user =
       toolchain_->add_subcommand(name, description)->group(group);
-  t_user->add_flag(kToolchainBuildFlag, toolchain_state.build);
-  t_user->add_flag(kToolchainTestFlag, toolchain_state.test);
+  t_user->add_flag(kToolchainBuildParam, toolchain_state.build);
+  t_user->add_flag(kToolchainTestParam, toolchain_state.test);
   return t_user;
 }
 

--- a/buildcc/lib/args/src/args.cpp
+++ b/buildcc/lib/args/src/args.cpp
@@ -18,8 +18,31 @@
 
 namespace {
 
+// Groups
+constexpr const char *const kRootGroup = "Root";
+
+// Options & Flags
+constexpr const char *const kHelpAllFlag = "--help-all";
+constexpr const char *const kHelpAllDesc = "Expand individual options.";
+
+constexpr const char *const kConfigFlag = "--config";
+constexpr const char *const kConfigDesc = "Read <config>.toml files.";
 constexpr int kMinFiles = 0;
-constexpr int kMaxFiles = INT_MAX;
+constexpr int kMaxFiles = 10;
+
+constexpr const char *const kCleanFlag = "--clean";
+constexpr const char *const kCleanDesc = "Clean artifacts";
+
+constexpr const char *const kLoglevelFlag = "--loglevel";
+constexpr const char *const kLoglevelDesc = "LogLevel settings";
+
+constexpr const char *const kRootDirFlag = "--root_dir";
+constexpr const char *const kRootDirDesc =
+    "Project root directory (relative to current directory)";
+
+constexpr const char *const kBuildDirFlag = "--build_dir";
+constexpr const char *const kBuildDirDesc =
+    "Project build dir (relative to current directory)";
 
 } // namespace
 
@@ -60,26 +83,23 @@ void Args::AddCustomTarget(const std::string &name,
 void Args::Initialize() { RootArgs(); }
 
 void Args::RootArgs() {
-  app_.set_help_all_flag("--help-all", "Expand individual options");
+  app_.set_help_all_flag(kHelpAllFlag, kHelpAllDesc);
 
-  app_.set_config("--config", "", "Read a <config>.toml file")
-      ->expected(kMinFiles, kMaxFiles);
+  app_.set_config(kConfigFlag, "", kConfigDesc)->expected(kMinFiles, kMaxFiles);
 
   // Root flags
-  app_.add_flag("--clean", clean_, "Clean artifacts")->group("Root");
-  app_.add_option("--loglevel", loglevel_, "LogLevel settings")
+  app_.add_flag(kCleanFlag, clean_, kCleanDesc)->group(kRootGroup);
+  app_.add_option(kLoglevelFlag, loglevel_, kLoglevelDesc)
       ->transform(CLI::CheckedTransformer(loglevel_map_, CLI::ignore_case))
-      ->group("Root");
+      ->group(kRootGroup);
 
   // Dir flags
-  app_.add_option("--root_dir", project_root_dir_,
-                  "Project root directory (relative to current directory)")
+  app_.add_option(kRootDirFlag, project_root_dir_, kRootDirDesc)
       ->required()
-      ->group("Root");
-  app_.add_option("--build_dir", project_build_dir_,
-                  "Project build dir (relative to current directory)")
+      ->group(kRootGroup);
+  app_.add_option(kBuildDirFlag, project_build_dir_, kBuildDirDesc)
       ->required()
-      ->group("Root");
+      ->group(kRootGroup);
 }
 
 void Args::CommonToolchainArgs() {

--- a/buildcc/lib/args/src/args.cpp
+++ b/buildcc/lib/args/src/args.cpp
@@ -48,6 +48,16 @@ constexpr const char *const kBuildDirDesc =
 constexpr const char *const kToolchainSubcommand = "toolchain";
 constexpr const char *const kToolchainDesc = "Select Toolchain";
 
+constexpr const char *const kToolchainBuildFlag = "--build";
+constexpr const char *const kToolchainTestFlag = "--test";
+constexpr const char *const kToolchainIdOption = "--id";
+constexpr const char *const kToolchainNameOption = "--name";
+constexpr const char *const kToolchainAsmCompilerOption = "--asm_compiler";
+constexpr const char *const kToolchainCCompilerOption = "--c_compiler";
+constexpr const char *const kToolchainCppCompilerOption = "--cpp_compiler";
+constexpr const char *const kToolchainArchiverOption = "--archiver";
+constexpr const char *const kToolchainLinkerOption = "--linker";
+
 constexpr const char *const kTargetSubcommand = "target";
 constexpr const char *const kTargetDesc = "Select Target";
 
@@ -77,18 +87,20 @@ void Args::AddCustomToolchain(const std::string &name,
                               const ToolchainArg &initial) {
   CLI::App *t_user = AddToolchain(name, description, "Custom", out.state);
 
-  t_user->add_option("--id", out.id, "Toolchain ID settings")
+  t_user->add_option(kToolchainIdOption, out.id, "Toolchain ID settings")
       ->transform(CLI::CheckedTransformer(kToolchainIdMap, CLI::ignore_case))
       ->default_val(initial.id);
-  t_user->add_option("--name", out.name)->default_val(initial.name);
-  t_user->add_option("--asm_compiler", out.asm_compiler)
+  t_user->add_option(kToolchainNameOption, out.name)->default_val(initial.name);
+  t_user->add_option(kToolchainAsmCompilerOption, out.asm_compiler)
       ->default_val(initial.asm_compiler);
-  t_user->add_option("--c_compiler", out.c_compiler)
+  t_user->add_option(kToolchainCCompilerOption, out.c_compiler)
       ->default_val(initial.c_compiler);
-  t_user->add_option("--cpp_compiler", out.cpp_compiler)
+  t_user->add_option(kToolchainCppCompilerOption, out.cpp_compiler)
       ->default_val(initial.cpp_compiler);
-  t_user->add_option("--archiver", out.archiver)->default_val(initial.archiver);
-  t_user->add_option("--linker", out.linker)->default_val(initial.linker);
+  t_user->add_option(kToolchainArchiverOption, out.archiver)
+      ->default_val(initial.archiver);
+  t_user->add_option(kToolchainLinkerOption, out.linker)
+      ->default_val(initial.linker);
 }
 
 void Args::AddCustomTarget(const std::string &name,
@@ -137,8 +149,8 @@ CLI::App *Args::AddToolchain(const std::string &name,
                              ToolchainState &toolchain_state) {
   CLI::App *t_user =
       toolchain_->add_subcommand(name, description)->group(group);
-  t_user->add_flag("-b,--build", toolchain_state.build);
-  t_user->add_flag("-t,--test", toolchain_state.test);
+  t_user->add_flag(kToolchainBuildFlag, toolchain_state.build);
+  t_user->add_flag(kToolchainTestFlag, toolchain_state.test);
   return t_user;
 }
 

--- a/buildcc/lib/args/src/args.cpp
+++ b/buildcc/lib/args/src/args.cpp
@@ -44,6 +44,13 @@ constexpr const char *const kBuildDirFlag = "--build_dir";
 constexpr const char *const kBuildDirDesc =
     "Project build dir (relative to current directory)";
 
+// Subcommands
+constexpr const char *const kToolchainSubcommand = "toolchain";
+constexpr const char *const kToolchainDesc = "Select Toolchain";
+
+constexpr const char *const kTargetSubcommand = "target";
+constexpr const char *const kTargetDesc = "Select Target";
+
 } // namespace
 
 namespace buildcc {
@@ -80,7 +87,11 @@ void Args::AddCustomTarget(const std::string &name,
 
 // Private
 
-void Args::Initialize() { RootArgs(); }
+void Args::Initialize() {
+  RootArgs();
+  toolchain_ = app_.add_subcommand(kToolchainSubcommand, kToolchainDesc);
+  target_ = app_.add_subcommand(kTargetSubcommand, kTargetDesc);
+}
 
 void Args::RootArgs() {
   app_.set_help_all_flag(kHelpAllFlag, kHelpAllDesc);
@@ -103,14 +114,11 @@ void Args::RootArgs() {
 }
 
 void Args::CommonToolchainArgs() {
-  toolchain_ = app_.add_subcommand("toolchain", "Select Toolchain");
   (void)AddToolchain("gcc", "GNU GCC Toolchain", "Supported", gcc_state_);
   (void)AddToolchain("msvc", "MSVC Toolchain", "Supported", msvc_state_);
 }
 
-void Args::CommonTargetArgs() {
-  target_ = app_.add_subcommand("target", "Select target");
-}
+void Args::CommonTargetArgs() {}
 
 CLI::App *Args::AddToolchain(const std::string &name,
                              const std::string &description,

--- a/buildcc/lib/args/src/args.cpp
+++ b/buildcc/lib/args/src/args.cpp
@@ -60,6 +60,13 @@ void Args::AddCustomToolchain(const std::string &name,
                               const ToolchainArg &initial) {
   CLI::App *t_user = AddToolchain(name, description, "Custom", out.state);
 
+  const std::unordered_map<std::string, base::Toolchain::Id> toolchain_id_map_{
+      {"gcc", base::Toolchain::Id::Gcc},
+      {"msvc", base::Toolchain::Id::Msvc},
+      {"clang", base::Toolchain::Id::Clang},
+      {"custom", base::Toolchain::Id::Custom},
+      {"undefined", base::Toolchain::Id::Undefined},
+  };
   t_user->add_option("--id", out.id, "Toolchain ID settings")
       ->transform(CLI::CheckedTransformer(toolchain_id_map_, CLI::ignore_case))
       ->default_val(initial.id);
@@ -99,6 +106,13 @@ void Args::RootArgs() {
   app_.set_config(kConfigFlag, "", kConfigDesc)->expected(kMinFiles, kMaxFiles);
 
   // Root flags
+  const std::unordered_map<std::string, env::LogLevel> loglevel_map_{
+      {"trace", env::LogLevel::Trace},
+      {"debug", env::LogLevel::Debug},
+      {"info", env::LogLevel::Info},
+      {"warning", env::LogLevel::Warning},
+      {"critical", env::LogLevel::Critical},
+  };
   app_.add_flag(kCleanFlag, clean_, kCleanDesc)->group(kRootGroup);
   app_.add_option(kLoglevelFlag, loglevel_, kLoglevelDesc)
       ->transform(CLI::CheckedTransformer(loglevel_map_, CLI::ignore_case))
@@ -112,13 +126,6 @@ void Args::RootArgs() {
       ->required()
       ->group(kRootGroup);
 }
-
-void Args::CommonToolchainArgs() {
-  (void)AddToolchain("gcc", "GNU GCC Toolchain", "Supported", gcc_state_);
-  (void)AddToolchain("msvc", "MSVC Toolchain", "Supported", msvc_state_);
-}
-
-void Args::CommonTargetArgs() {}
 
 CLI::App *Args::AddToolchain(const std::string &name,
                              const std::string &description,

--- a/buildcc/lib/args/src/args.cpp
+++ b/buildcc/lib/args/src/args.cpp
@@ -62,7 +62,7 @@ constexpr const char *const kToolchainLinkerParam = "--linker";
 
 constexpr const char *const kTargetSubcommand = "target";
 constexpr const char *const kTargetDesc = "Select Target";
-constexpr const char *const kTargetGroup = "Custom Target";
+constexpr const char *const kTargetGroup = "Custom Targets";
 
 constexpr const char *const kTargetCompileCommandParam = "--compile_command";
 constexpr const char *const kTargetLinkCommandParam = "--link_command";

--- a/buildcc/lib/args/src/args.cpp
+++ b/buildcc/lib/args/src/args.cpp
@@ -82,10 +82,12 @@ const std::unordered_map<const char *, buildcc::base::Toolchain::Id>
 
 namespace buildcc {
 
-void Args::AddCustomToolchain(const std::string &name,
-                              const std::string &description, ToolchainArg &out,
-                              const ToolchainArg &initial) {
-  CLI::App *t_user = AddToolchain(name, description, "Custom", out.state);
+void Args::AddToolchain(const std::string &name, const std::string &description,
+                        ToolchainArg &out, const ToolchainArg &initial) {
+  CLI::App *t_user = toolchain_->add_subcommand(name, description)
+                         ->group("Supported Toolchains");
+  t_user->add_flag(kToolchainBuildParam, out.state.build);
+  t_user->add_flag(kToolchainTestParam, out.state.test);
 
   t_user->add_option(kToolchainIdParam, out.id, "Toolchain ID settings")
       ->transform(CLI::CheckedTransformer(kToolchainIdMap, CLI::ignore_case))
@@ -103,9 +105,8 @@ void Args::AddCustomToolchain(const std::string &name,
       ->default_val(initial.linker);
 }
 
-void Args::AddCustomTarget(const std::string &name,
-                           const std::string &description, TargetArg &out,
-                           const TargetArg &initial) {
+void Args::AddTarget(const std::string &name, const std::string &description,
+                     TargetArg &out, const TargetArg &initial) {
   CLI::App *target_user =
       target_->add_subcommand(name, description)->group("Custom");
   target_user->add_option("--compile_command", out.compile_command)
@@ -142,17 +143,6 @@ void Args::RootArgs() {
   app_.add_option(kBuildDirParam, project_build_dir_, kBuildDirDesc)
       ->required()
       ->group(kRootGroup);
-}
-
-CLI::App *Args::AddToolchain(const std::string &name,
-                             const std::string &description,
-                             const std::string &group,
-                             ToolchainState &toolchain_state) {
-  CLI::App *t_user =
-      toolchain_->add_subcommand(name, description)->group(group);
-  t_user->add_flag(kToolchainBuildParam, toolchain_state.build);
-  t_user->add_flag(kToolchainTestParam, toolchain_state.test);
-  return t_user;
 }
 
 } // namespace buildcc

--- a/buildcc/lib/args/src/args.cpp
+++ b/buildcc/lib/args/src/args.cpp
@@ -48,22 +48,17 @@ void Args::AddCustomTarget(const std::string &name,
       ->default_val(initial.link_command);
 }
 
-void Args::Parse(int argc, char **argv) {
+void Args::Parse(int argc, const char *const *argv) {
   try {
     app_.parse(argc, argv);
   } catch (const CLI::ParseError &e) {
-    env::log_critical("Args::Parse", e.what());
     exit(app_.exit(e));
   }
 }
 
 // Private
 
-void Args::Initialize() {
-  RootArgs();
-  CommonToolchainArgs();
-  CommonTargetArgs();
-}
+void Args::Initialize() { RootArgs(); }
 
 void Args::RootArgs() {
   app_.set_help_all_flag("--help-all", "Expand individual options");
@@ -74,8 +69,8 @@ void Args::RootArgs() {
   app_.set_config("--config", "", "Read a <config>.toml file")->expected(1);
 
   // Root flags
-  app_.add_flag("-c,--clean", clean_, "Clean artifacts")->group("Root");
-  app_.add_option("-l,--loglevel", loglevel_, "LogLevel settings")
+  app_.add_flag("--clean", clean_, "Clean artifacts")->group("Root");
+  app_.add_option("--loglevel", loglevel_, "LogLevel settings")
       ->transform(CLI::CheckedTransformer(loglevel_map_, CLI::ignore_case))
       ->group("Root");
 

--- a/buildcc/lib/args/src/args.cpp
+++ b/buildcc/lib/args/src/args.cpp
@@ -48,14 +48,6 @@ void Args::AddCustomTarget(const std::string &name,
       ->default_val(initial.link_command);
 }
 
-void Args::Parse(int argc, const char *const *argv) {
-  try {
-    app_.parse(argc, argv);
-  } catch (const CLI::ParseError &e) {
-    exit(app_.exit(e));
-  }
-}
-
 // Private
 
 void Args::Initialize() { RootArgs(); }

--- a/buildcc/lib/args/src/parse.cpp
+++ b/buildcc/lib/args/src/parse.cpp
@@ -1,0 +1,13 @@
+#include "args/args.h"
+
+namespace buildcc {
+
+void Args::Parse(int argc, const char *const *argv) {
+  try {
+    app_.parse(argc, argv);
+  } catch (const CLI::ParseError &e) {
+    exit(app_.exit(e));
+  }
+}
+
+} // namespace buildcc

--- a/buildcc/lib/args/test/configs/basic_parse.toml
+++ b/buildcc/lib/args/test/configs/basic_parse.toml
@@ -1,0 +1,7 @@
+# Root
+root_dir = "root"
+build_dir = "build"
+loglevel = "trace"
+
+# Project
+clean = true

--- a/buildcc/lib/args/test/configs/gcc_target.toml
+++ b/buildcc/lib/args/test/configs/gcc_target.toml
@@ -1,0 +1,3 @@
+[target.gcc]
+compile_command = "{compiler} {preprocessor_flags} {include_dirs} {common_compile_flags} {compile_flags} -o {output} -c {input}"
+link_command = "{cpp_compiler} {link_flags} {compiled_sources} -o {output} {lib_dirs} {lib_deps}"

--- a/buildcc/lib/args/test/configs/gcc_toolchain.toml
+++ b/buildcc/lib/args/test/configs/gcc_toolchain.toml
@@ -1,0 +1,11 @@
+# Depending on the compile_command and link_command associated with the relevant target these are the minimal parameters required
+[toolchain.gcc]
+build = true
+test = false
+id = "gcc"
+name = "gcc"
+asm_compiler = "as"
+c_compiler = "gcc"
+cpp_compiler = "g++"
+archiver = "ar"
+linker = "ld"

--- a/buildcc/lib/args/test/configs/msvc_target.toml
+++ b/buildcc/lib/args/test/configs/msvc_target.toml
@@ -1,0 +1,4 @@
+[target.msvc]
+compile_command = "{compiler} {preprocessor_flags} {include_dirs} {common_compile_flags} {compile_flags} /Fo{output} /c {input}"
+link_command = "{linker} {link_flags} {lib_dirs} /OUT:{output} {lib_deps} {compiled_sources}"
+

--- a/buildcc/lib/args/test/configs/msvc_toolchain.toml
+++ b/buildcc/lib/args/test/configs/msvc_toolchain.toml
@@ -1,0 +1,11 @@
+# Depending on the compile_command and link_command associated with the relevant target these are the minimal parameters required
+[toolchain.msvc]
+build = true
+test = true
+id = "msvc"
+name = "msvc"
+asm_compiler = "cl"
+c_compiler = "cl"
+cpp_compiler = "cl"
+archiver = "lib"
+linker = "link"

--- a/buildcc/lib/args/test/configs/no_clean.toml
+++ b/buildcc/lib/args/test/configs/no_clean.toml
@@ -1,0 +1,2 @@
+# Project
+clean = false

--- a/buildcc/lib/args/test/test_args.cpp
+++ b/buildcc/lib/args/test/test_args.cpp
@@ -21,6 +21,7 @@ TEST(ArgsTestGroup, Args_BasicParse) {
 
   STRCMP_EQUAL(args.GetProjectRootDir().string().c_str(), "root");
   STRCMP_EQUAL(args.GetProjectBuildDir().string().c_str(), "build");
+  CHECK(args.GetLogLevel() == buildcc::env::LogLevel::Trace);
   CHECK_TRUE(args.Clean());
 }
 
@@ -43,6 +44,7 @@ TEST(ArgsTestGroup, Args_MultiToml) {
 
   STRCMP_EQUAL(args.GetProjectRootDir().string().c_str(), "root");
   STRCMP_EQUAL(args.GetProjectBuildDir().string().c_str(), "build");
+  CHECK(args.GetLogLevel() == buildcc::env::LogLevel::Trace);
   CHECK_FALSE(args.Clean());
 }
 

--- a/buildcc/lib/args/test/test_args.cpp
+++ b/buildcc/lib/args/test/test_args.cpp
@@ -75,7 +75,54 @@ TEST(ArgsTestGroup, Args_CustomToolchain) {
   STRCMP_EQUAL(gcc_toolchain.linker.c_str(), "ld");
 }
 
-TEST(ArgsTestGroup, Args_MultipleCustomToolchain) {}
+TEST(ArgsTestGroup, Args_MultipleCustomToolchain) {
+  std::vector<const char *> av{
+      "",
+      "--config",
+      "configs/basic_parse.toml",
+      "--config",
+      "configs/gcc_toolchain.toml",
+      "--config",
+      "configs/msvc_toolchain.toml",
+  };
+  int argc = av.size();
+
+  buildcc::Args args;
+  buildcc::Args::ToolchainArg gcc_toolchain;
+  buildcc::Args::ToolchainArg msvc_toolchain;
+  args.AddCustomToolchain("gcc", "Generic gcc toolchain", gcc_toolchain);
+  args.AddCustomToolchain("msvc", "Generic msvc toolchain", msvc_toolchain);
+  args.Parse(argc, av.data());
+
+  STRCMP_EQUAL(args.GetProjectRootDir().string().c_str(), "root");
+  STRCMP_EQUAL(args.GetProjectBuildDir().string().c_str(), "build");
+  CHECK(args.GetLogLevel() == buildcc::env::LogLevel::Trace);
+  CHECK_TRUE(args.Clean());
+
+  // Toolchain
+
+  // GCC
+  CHECK_TRUE(gcc_toolchain.state.build);
+  CHECK_FALSE(gcc_toolchain.state.test);
+  CHECK(gcc_toolchain.id == buildcc::base::Toolchain::Id::Gcc);
+  STRCMP_EQUAL(gcc_toolchain.name.c_str(), "gcc");
+  STRCMP_EQUAL(gcc_toolchain.asm_compiler.c_str(), "as");
+  STRCMP_EQUAL(gcc_toolchain.c_compiler.c_str(), "gcc");
+  STRCMP_EQUAL(gcc_toolchain.cpp_compiler.c_str(), "g++");
+  STRCMP_EQUAL(gcc_toolchain.archiver.c_str(), "ar");
+  STRCMP_EQUAL(gcc_toolchain.linker.c_str(), "ld");
+
+  // MSVC
+  CHECK_TRUE(msvc_toolchain.state.build);
+  CHECK_TRUE(msvc_toolchain.state.test);
+  CHECK(msvc_toolchain.id == buildcc::base::Toolchain::Id::Msvc);
+  STRCMP_EQUAL(msvc_toolchain.name.c_str(), "msvc");
+  STRCMP_EQUAL(msvc_toolchain.asm_compiler.c_str(), "cl");
+  STRCMP_EQUAL(msvc_toolchain.c_compiler.c_str(), "cl");
+  STRCMP_EQUAL(msvc_toolchain.cpp_compiler.c_str(), "cl");
+  STRCMP_EQUAL(msvc_toolchain.archiver.c_str(), "lib");
+  STRCMP_EQUAL(msvc_toolchain.linker.c_str(), "link");
+}
 
 TEST(ArgsTestGroup, Args_DuplicateCustomToolchain) {}
 

--- a/buildcc/lib/args/test/test_args.cpp
+++ b/buildcc/lib/args/test/test_args.cpp
@@ -33,6 +33,19 @@ TEST(ArgsTestGroup, Args_BasicExit) {
   CHECK_THROWS(std::exception, args.Parse(argc, av.data()));
 }
 
+TEST(ArgsTestGroup, Args_MultiToml) {
+  std::vector<const char *> av{"", "--config", "configs/basic_parse.toml",
+                               "--config", "configs/no_clean.toml"};
+  int argc = av.size();
+
+  buildcc::Args args;
+  args.Parse(argc, av.data());
+
+  STRCMP_EQUAL(args.GetProjectRootDir().string().c_str(), "root");
+  STRCMP_EQUAL(args.GetProjectBuildDir().string().c_str(), "build");
+  CHECK_FALSE(args.Clean());
+}
+
 int main(int ac, char **av) {
   return CommandLineTestRunner::RunAllTests(ac, av);
 }

--- a/buildcc/lib/args/test/test_args.cpp
+++ b/buildcc/lib/args/test/test_args.cpp
@@ -182,7 +182,80 @@ TEST(ArgsTestGroup, Args_CustomTarget) {
                "{lib_dirs} {lib_deps}");
 }
 
-TEST(ArgsTestGroup, Args_MultipleCustomTarget) {}
+TEST(ArgsTestGroup, Args_MultipleCustomTarget) {
+  std::vector<const char *> av{
+      "",
+      "--config",
+      "configs/basic_parse.toml",
+      "--config",
+      "configs/gcc_toolchain.toml",
+      "--config",
+      "configs/gcc_target.toml",
+      "--config",
+      "configs/msvc_toolchain.toml",
+      "--config",
+      "configs/msvc_target.toml",
+  };
+  int argc = av.size();
+
+  buildcc::Args args;
+  buildcc::Args::ToolchainArg gcc_toolchain;
+  buildcc::Args::TargetArg gcc_target;
+  args.AddToolchain("gcc", "Generic gcc toolchain", gcc_toolchain);
+  args.AddTarget("gcc", "Generic gcc target", gcc_target);
+  buildcc::Args::ToolchainArg msvc_toolchain;
+  buildcc::Args::TargetArg msvc_target;
+  args.AddToolchain("msvc", "Generic msvc toolchain", msvc_toolchain);
+  args.AddTarget("msvc", "Generic msvc target", msvc_target);
+  args.Parse(argc, av.data());
+
+  STRCMP_EQUAL(args.GetProjectRootDir().string().c_str(), "root");
+  STRCMP_EQUAL(args.GetProjectBuildDir().string().c_str(), "build");
+  CHECK(args.GetLogLevel() == buildcc::env::LogLevel::Trace);
+  CHECK_TRUE(args.Clean());
+
+  // GCC
+
+  // Toolchain
+  CHECK_TRUE(gcc_toolchain.state.build);
+  CHECK_FALSE(gcc_toolchain.state.test);
+  CHECK(gcc_toolchain.id == buildcc::base::Toolchain::Id::Gcc);
+  STRCMP_EQUAL(gcc_toolchain.name.c_str(), "gcc");
+  STRCMP_EQUAL(gcc_toolchain.asm_compiler.c_str(), "as");
+  STRCMP_EQUAL(gcc_toolchain.c_compiler.c_str(), "gcc");
+  STRCMP_EQUAL(gcc_toolchain.cpp_compiler.c_str(), "g++");
+  STRCMP_EQUAL(gcc_toolchain.archiver.c_str(), "ar");
+  STRCMP_EQUAL(gcc_toolchain.linker.c_str(), "ld");
+
+  // Target
+  STRCMP_EQUAL(gcc_target.compile_command.c_str(),
+               "{compiler} {preprocessor_flags} {include_dirs} "
+               "{common_compile_flags} {compile_flags} -o {output} -c {input}");
+  STRCMP_EQUAL(gcc_target.link_command.c_str(),
+               "{cpp_compiler} {link_flags} {compiled_sources} -o {output} "
+               "{lib_dirs} {lib_deps}");
+
+  // MSVC
+
+  // Toolchain
+  CHECK_TRUE(msvc_toolchain.state.build);
+  CHECK_TRUE(msvc_toolchain.state.test);
+  CHECK(msvc_toolchain.id == buildcc::base::Toolchain::Id::Msvc);
+  STRCMP_EQUAL(msvc_toolchain.name.c_str(), "msvc");
+  STRCMP_EQUAL(msvc_toolchain.asm_compiler.c_str(), "cl");
+  STRCMP_EQUAL(msvc_toolchain.c_compiler.c_str(), "cl");
+  STRCMP_EQUAL(msvc_toolchain.cpp_compiler.c_str(), "cl");
+  STRCMP_EQUAL(msvc_toolchain.archiver.c_str(), "lib");
+  STRCMP_EQUAL(msvc_toolchain.linker.c_str(), "link");
+
+  // Target
+  STRCMP_EQUAL(msvc_target.compile_command.c_str(),
+               "{compiler} {preprocessor_flags} {include_dirs} "
+               "{common_compile_flags} {compile_flags} /Fo{output} /c {input}");
+  STRCMP_EQUAL(msvc_target.link_command.c_str(),
+               "{linker} {link_flags} {lib_dirs} /OUT:{output} {lib_deps} "
+               "{compiled_sources}");
+}
 
 int main(int ac, char **av) {
   return CommandLineTestRunner::RunAllTests(ac, av);

--- a/buildcc/lib/args/test/test_args.cpp
+++ b/buildcc/lib/args/test/test_args.cpp
@@ -1,0 +1,38 @@
+#include "args/args.h"
+
+// NOTE, Make sure all these includes are AFTER the system and header includes
+#include "CppUTest/CommandLineTestRunner.h"
+#include "CppUTest/MemoryLeakDetectorNewMacros.h"
+#include "CppUTest/TestHarness.h"
+#include "CppUTest/Utest.h"
+
+// clang-format off
+TEST_GROUP(ArgsTestGroup)
+{
+};
+// clang-format on
+
+TEST(ArgsTestGroup, Args_BasicParse) {
+  std::vector<const char *> av{"", "--config", "configs/basic_parse.toml"};
+  int argc = av.size();
+
+  buildcc::Args args;
+  args.Parse(argc, av.data());
+
+  STRCMP_EQUAL(args.GetProjectRootDir().string().c_str(), "root");
+  STRCMP_EQUAL(args.GetProjectBuildDir().string().c_str(), "build");
+  CHECK_TRUE(args.Clean());
+}
+
+TEST(ArgsTestGroup, Args_BasicExit) {
+  std::vector<const char *> av{"", "--config", "configs/basic_parse.toml",
+                               "--help"};
+  int argc = av.size();
+
+  buildcc::Args args;
+  CHECK_THROWS(std::exception, args.Parse(argc, av.data()));
+}
+
+int main(int ac, char **av) {
+  return CommandLineTestRunner::RunAllTests(ac, av);
+}

--- a/buildcc/lib/args/test/test_args.cpp
+++ b/buildcc/lib/args/test/test_args.cpp
@@ -138,6 +138,52 @@ TEST(ArgsTestGroup, Args_DuplicateCustomToolchain) {
                                                  other_gcc_toolchain));
 }
 
+TEST(ArgsTestGroup, Args_CustomTarget) {
+  std::vector<const char *> av{
+      "",
+      "--config",
+      "configs/basic_parse.toml",
+      "--config",
+      "configs/gcc_toolchain.toml",
+      "--config",
+      "configs/gcc_target.toml",
+  };
+  int argc = av.size();
+
+  buildcc::Args args;
+  buildcc::Args::ToolchainArg gcc_toolchain;
+  buildcc::Args::TargetArg gcc_target;
+  args.AddToolchain("gcc", "Generic gcc toolchain", gcc_toolchain);
+  args.AddTarget("gcc", "Generic gcc target", gcc_target);
+  args.Parse(argc, av.data());
+
+  STRCMP_EQUAL(args.GetProjectRootDir().string().c_str(), "root");
+  STRCMP_EQUAL(args.GetProjectBuildDir().string().c_str(), "build");
+  CHECK(args.GetLogLevel() == buildcc::env::LogLevel::Trace);
+  CHECK_TRUE(args.Clean());
+
+  // Toolchain
+  CHECK_TRUE(gcc_toolchain.state.build);
+  CHECK_FALSE(gcc_toolchain.state.test);
+  CHECK(gcc_toolchain.id == buildcc::base::Toolchain::Id::Gcc);
+  STRCMP_EQUAL(gcc_toolchain.name.c_str(), "gcc");
+  STRCMP_EQUAL(gcc_toolchain.asm_compiler.c_str(), "as");
+  STRCMP_EQUAL(gcc_toolchain.c_compiler.c_str(), "gcc");
+  STRCMP_EQUAL(gcc_toolchain.cpp_compiler.c_str(), "g++");
+  STRCMP_EQUAL(gcc_toolchain.archiver.c_str(), "ar");
+  STRCMP_EQUAL(gcc_toolchain.linker.c_str(), "ld");
+
+  // Target
+  STRCMP_EQUAL(gcc_target.compile_command.c_str(),
+               "{compiler} {preprocessor_flags} {include_dirs} "
+               "{common_compile_flags} {compile_flags} -o {output} -c {input}");
+  STRCMP_EQUAL(gcc_target.link_command.c_str(),
+               "{cpp_compiler} {link_flags} {compiled_sources} -o {output} "
+               "{lib_dirs} {lib_deps}");
+}
+
+TEST(ArgsTestGroup, Args_MultipleCustomTarget) {}
+
 int main(int ac, char **av) {
   return CommandLineTestRunner::RunAllTests(ac, av);
 }

--- a/buildcc/lib/args/test/test_args.cpp
+++ b/buildcc/lib/args/test/test_args.cpp
@@ -55,7 +55,7 @@ TEST(ArgsTestGroup, Args_CustomToolchain) {
 
   buildcc::Args args;
   buildcc::Args::ToolchainArg gcc_toolchain;
-  args.AddCustomToolchain("gcc", "Generic gcc toolchain", gcc_toolchain);
+  args.AddToolchain("gcc", "Generic gcc toolchain", gcc_toolchain);
   args.Parse(argc, av.data());
 
   STRCMP_EQUAL(args.GetProjectRootDir().string().c_str(), "root");
@@ -90,8 +90,8 @@ TEST(ArgsTestGroup, Args_MultipleCustomToolchain) {
   buildcc::Args args;
   buildcc::Args::ToolchainArg gcc_toolchain;
   buildcc::Args::ToolchainArg msvc_toolchain;
-  args.AddCustomToolchain("gcc", "Generic gcc toolchain", gcc_toolchain);
-  args.AddCustomToolchain("msvc", "Generic msvc toolchain", msvc_toolchain);
+  args.AddToolchain("gcc", "Generic gcc toolchain", gcc_toolchain);
+  args.AddToolchain("msvc", "Generic msvc toolchain", msvc_toolchain);
   args.Parse(argc, av.data());
 
   STRCMP_EQUAL(args.GetProjectRootDir().string().c_str(), "root");
@@ -128,15 +128,14 @@ TEST(ArgsTestGroup, Args_DuplicateCustomToolchain) {
   buildcc::Args args;
   buildcc::Args::ToolchainArg gcc_toolchain;
   buildcc::Args::ToolchainArg other_gcc_toolchain;
-  args.AddCustomToolchain("gcc", "Generic gcc toolchain", gcc_toolchain);
+  args.AddToolchain("gcc", "Generic gcc toolchain", gcc_toolchain);
 
   // CLI11 Throws an exception when multiple toolchains with same name are added
   // NOTE, This behaviour does not need to be tested since it is provided by
   // CLI11
   // This test is as an example of wrong usage by the user
-  CHECK_THROWS(std::exception,
-               args.AddCustomToolchain("gcc", "Other gcc toolchain",
-                                       other_gcc_toolchain));
+  CHECK_THROWS(std::exception, args.AddToolchain("gcc", "Other gcc toolchain",
+                                                 other_gcc_toolchain));
 }
 
 int main(int ac, char **av) {

--- a/buildcc/lib/args/test/test_args.cpp
+++ b/buildcc/lib/args/test/test_args.cpp
@@ -48,6 +48,37 @@ TEST(ArgsTestGroup, Args_MultiToml) {
   CHECK_FALSE(args.Clean());
 }
 
+TEST(ArgsTestGroup, Args_CustomToolchain) {
+  std::vector<const char *> av{"", "--config", "configs/basic_parse.toml",
+                               "--config", "configs/gcc_toolchain.toml"};
+  int argc = av.size();
+
+  buildcc::Args args;
+  buildcc::Args::ToolchainArg gcc_toolchain;
+  args.AddCustomToolchain("gcc", "Generic gcc toolchain", gcc_toolchain);
+  args.Parse(argc, av.data());
+
+  STRCMP_EQUAL(args.GetProjectRootDir().string().c_str(), "root");
+  STRCMP_EQUAL(args.GetProjectBuildDir().string().c_str(), "build");
+  CHECK(args.GetLogLevel() == buildcc::env::LogLevel::Trace);
+  CHECK_TRUE(args.Clean());
+
+  // Toolchain
+  CHECK_TRUE(gcc_toolchain.state.build);
+  CHECK_FALSE(gcc_toolchain.state.test);
+  CHECK(gcc_toolchain.id == buildcc::base::Toolchain::Id::Gcc);
+  STRCMP_EQUAL(gcc_toolchain.name.c_str(), "gcc");
+  STRCMP_EQUAL(gcc_toolchain.asm_compiler.c_str(), "as");
+  STRCMP_EQUAL(gcc_toolchain.c_compiler.c_str(), "gcc");
+  STRCMP_EQUAL(gcc_toolchain.cpp_compiler.c_str(), "g++");
+  STRCMP_EQUAL(gcc_toolchain.archiver.c_str(), "ar");
+  STRCMP_EQUAL(gcc_toolchain.linker.c_str(), "ld");
+}
+
+TEST(ArgsTestGroup, Args_MultipleCustomToolchain) {}
+
+TEST(ArgsTestGroup, Args_DuplicateCustomToolchain) {}
+
 int main(int ac, char **av) {
   return CommandLineTestRunner::RunAllTests(ac, av);
 }

--- a/buildcc/lib/args/test/test_args.cpp
+++ b/buildcc/lib/args/test/test_args.cpp
@@ -124,7 +124,20 @@ TEST(ArgsTestGroup, Args_MultipleCustomToolchain) {
   STRCMP_EQUAL(msvc_toolchain.linker.c_str(), "link");
 }
 
-TEST(ArgsTestGroup, Args_DuplicateCustomToolchain) {}
+TEST(ArgsTestGroup, Args_DuplicateCustomToolchain) {
+  buildcc::Args args;
+  buildcc::Args::ToolchainArg gcc_toolchain;
+  buildcc::Args::ToolchainArg other_gcc_toolchain;
+  args.AddCustomToolchain("gcc", "Generic gcc toolchain", gcc_toolchain);
+
+  // CLI11 Throws an exception when multiple toolchains with same name are added
+  // NOTE, This behaviour does not need to be tested since it is provided by
+  // CLI11
+  // This test is as an example of wrong usage by the user
+  CHECK_THROWS(std::exception,
+               args.AddCustomToolchain("gcc", "Other gcc toolchain",
+                                       other_gcc_toolchain));
+}
 
 int main(int ac, char **av) {
   return CommandLineTestRunner::RunAllTests(ac, av);

--- a/cmake/coverage/gcovr.cmake
+++ b/cmake/coverage/gcovr.cmake
@@ -9,15 +9,17 @@ else()
 message("GCOVR at ${gcovr_program}")
 
 set(GCOVR_REMOVE_OPTIONS 
-    --exclude "(.+/)?generated(.+/)?"
-    --exclude "(.+/)?test(.+/)?"
     --exclude "(.+/)?flatbuffers(.+/)?"
     --exclude "(.+/)?spdlog(.+/)?"
-    --exclude "(.+/)?CppUTest(.+/)?"
-    --exclude "(.+/)?CppUTestExt(.+/)?"
-    --exclude "(.+/)?mock(.+/)?"
     --exclude "(.+/)?fmt(.+/)?"
     --exclude "(.+/)?taskflow(.+/)?"
+    --exclude "(.+/)?CLI11(.+/)?"
+    --exclude "(.+/)?CppUTest(.+/)?"
+    --exclude "(.+/)?CppUTestExt(.+/)?"
+
+    --exclude "(.+/)?mock(.+/)?"
+    --exclude "(.+/)?generated(.+/)?"
+    --exclude "(.+/)?test(.+/)?"
 )
 
 # TODO, Update

--- a/example/hybrid/custom_target/build.main.cpp
+++ b/example/hybrid/custom_target/build.main.cpp
@@ -10,8 +10,12 @@ static constexpr std::string_view EXE = "build";
 int main(int argc, char **argv) {
   // 1. Get arguments
   Args args;
+  Args::ToolchainArg arg_gcc;
+  Args::ToolchainArg arg_msvc;
   Args::ToolchainArg toolchain_clang_gnu;
   Args::TargetArg target_clang_gnu;
+  args.AddToolchain("gcc", "Generic gcc toolchain", arg_gcc);
+  args.AddToolchain("msvc", "Generic msvc toolchain", arg_msvc);
   args.AddToolchain("clang_gnu", "Clang GNU toolchain", toolchain_clang_gnu);
   args.AddTarget("clang_gnu", "Clang GNU target", target_clang_gnu);
   args.Parse(argc, argv);
@@ -30,8 +34,8 @@ int main(int argc, char **argv) {
   ExecutableTarget_gcc g_foolib("foolib", gcc, "");
   ExecutableTarget_msvc m_foolib("foolib", msvc, "");
 
-  reg.Build(args.GetGccState(), g_foolib, foolib_build_cb);
-  reg.Build(args.GetMsvcState(), m_foolib, foolib_build_cb);
+  reg.Build(arg_gcc.state, g_foolib, foolib_build_cb);
+  reg.Build(arg_msvc.state, m_foolib, foolib_build_cb);
 
   // * NOTE, This is how we add our custom toolchain
   base::Toolchain clang = toolchain_clang_gnu.ConstructToolchain();

--- a/example/hybrid/custom_target/build.main.cpp
+++ b/example/hybrid/custom_target/build.main.cpp
@@ -12,9 +12,8 @@ int main(int argc, char **argv) {
   Args args;
   Args::ToolchainArg toolchain_clang_gnu;
   Args::TargetArg target_clang_gnu;
-  args.AddCustomToolchain("clang_gnu", "Clang GNU toolchain",
-                          toolchain_clang_gnu);
-  args.AddCustomTarget("clang_gnu", "Clang GNU target", target_clang_gnu);
+  args.AddToolchain("clang_gnu", "Clang GNU toolchain", toolchain_clang_gnu);
+  args.AddTarget("clang_gnu", "Clang GNU target", target_clang_gnu);
   args.Parse(argc, argv);
 
   // 2. Initialize your environment

--- a/example/hybrid/external_lib/build.main.cpp
+++ b/example/hybrid/external_lib/build.main.cpp
@@ -10,6 +10,10 @@ static void foolib_build_cb(base::Target &target);
 int main(int argc, char **argv) {
   // 1. Get arguments
   Args args;
+  Args::ToolchainArg arg_gcc;
+  Args::ToolchainArg arg_msvc;
+  args.AddToolchain("gcc", "Generic gcc toolchain", arg_gcc);
+  args.AddToolchain("msvc", "Generic msvc toolchain", arg_msvc);
   args.Parse(argc, argv);
 
   // 2. Initialize your environment
@@ -26,8 +30,8 @@ int main(int argc, char **argv) {
   ExecutableTarget_gcc g_foolib("cppflags", gcc, "");
   ExecutableTarget_msvc m_foolib("cppflags", msvc, "");
 
-  reg.Build(args.GetGccState(), g_foolib, foolib_build_cb);
-  reg.Build(args.GetMsvcState(), m_foolib, foolib_build_cb);
+  reg.Build(arg_gcc.state, g_foolib, foolib_build_cb);
+  reg.Build(arg_msvc.state, m_foolib, foolib_build_cb);
 
   // 5.
   reg.RunBuild();

--- a/example/hybrid/foolib/build.main.cpp
+++ b/example/hybrid/foolib/build.main.cpp
@@ -10,6 +10,10 @@ static void foolib_build_cb(base::Target &target);
 int main(int argc, char **argv) {
   // 1. Get arguments
   Args args;
+  Args::ToolchainArg arg_gcc;
+  Args::ToolchainArg arg_msvc;
+  args.AddToolchain("gcc", "Generic gcc toolchain", arg_gcc);
+  args.AddToolchain("msvc", "Generic msvc toolchain", arg_msvc);
   args.Parse(argc, argv);
 
   // 2. Initialize your environment
@@ -26,8 +30,8 @@ int main(int argc, char **argv) {
   ExecutableTarget_gcc g_foolib("foolib", gcc, "");
   ExecutableTarget_msvc m_foolib("foolib", msvc, "");
 
-  reg.Build(args.GetGccState(), g_foolib, foolib_build_cb);
-  reg.Build(args.GetMsvcState(), m_foolib, foolib_build_cb);
+  reg.Build(arg_gcc.state, g_foolib, foolib_build_cb);
+  reg.Build(arg_msvc.state, m_foolib, foolib_build_cb);
 
   // 5.
   reg.RunBuild();

--- a/example/hybrid/generic/build.cpp
+++ b/example/hybrid/generic/build.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
         ->group("Custom");
 
     // NOTE, You can add more custom toolchains as per your requirement
-    args.AddCustomToolchain("user", "User defined toolchain", custom_toolchain);
+    args.AddToolchain("user", "User defined toolchain", custom_toolchain);
   } catch (const std::exception &e) {
     std::cout << "EXCEPTION " << e.what() << std::endl;
   }

--- a/example/hybrid/simple/build.cpp
+++ b/example/hybrid/simple/build.cpp
@@ -14,6 +14,10 @@ static void cflags_build_cb(base::Target &cflags);
 int main(int argc, char **argv) {
   // 1. Get arguments
   Args args;
+  Args::ToolchainArg arg_gcc;
+  Args::ToolchainArg arg_msvc;
+  args.AddToolchain("gcc", "Generic gcc toolchain", arg_gcc);
+  args.AddToolchain("msvc", "Generic msvc toolchain", arg_msvc);
   args.Parse(argc, argv);
 
   // 2. Initialize your environment
@@ -34,17 +38,17 @@ int main(int argc, char **argv) {
   ExecutableTarget_msvc m_cflags("cflags", msvc, "files");
 
   // Select your builds and tests using the .toml files
-  reg.Build(args.GetGccState(), g_cppflags, cppflags_build_cb);
-  reg.Build(args.GetMsvcState(), m_cppflags, cppflags_build_cb);
-  reg.Build(args.GetGccState(), g_cflags, cflags_build_cb);
-  reg.Build(args.GetMsvcState(), m_cflags, cflags_build_cb);
+  reg.Build(arg_gcc.state, g_cppflags, cppflags_build_cb);
+  reg.Build(arg_msvc.state, m_cppflags, cppflags_build_cb);
+  reg.Build(arg_gcc.state, g_cflags, cflags_build_cb);
+  reg.Build(arg_msvc.state, m_cflags, cflags_build_cb);
 
   // 5. Test steps
   // NOTE, For now they are just dummy callbacks
-  reg.Test(args.GetGccState(), g_cppflags, [](base::Target &target) {});
-  reg.Test(args.GetMsvcState(), m_cppflags, [](base::Target &target) {});
-  reg.Test(args.GetGccState(), g_cflags, [](base::Target &target) {});
-  reg.Test(args.GetMsvcState(), m_cflags, [](base::Target &target) {});
+  reg.Test(arg_gcc.state, g_cppflags, [](base::Target &target) {});
+  reg.Test(arg_msvc.state, m_cppflags, [](base::Target &target) {});
+  reg.Test(arg_gcc.state, g_cflags, [](base::Target &target) {});
+  reg.Test(arg_msvc.state, m_cflags, [](base::Target &target) {});
 
   // 6. Build Target
   reg.RunBuild();


### PR DESCRIPTION
- Updated Args with unit tests
- Updated Args design (Removed default GCC and MSVC toolchain args) and make user register Toolchain arg as required
- Updated CLI11 with v2.1.0, Can now concat multiple *.toml files (Upto 10 toml files can be concat using the --config parameter)