### PR TITLE
Reg updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ _deps
 *build/
 *_build_*/
 .vscode/
+.vs/
+.idea/
 
 # Files
 *.gcov

--- a/buildcc/lib/args/include/args/register.h
+++ b/buildcc/lib/args/include/args/register.h
@@ -73,6 +73,8 @@ public:
   // Getters
   const tf::Taskflow &GetTaskflow() const { return targets_.tf; }
 
+  std::string Graph() { return graphs_.tf.dump(); }
+
 private:
   struct TestInfo {
     base::Target &target_;

--- a/buildcc/lib/args/include/args/register.h
+++ b/buildcc/lib/args/include/args/register.h
@@ -87,10 +87,8 @@ private:
     std::unordered_map<fs::path, tf::Task, internal::PathHash> relation;
     tf::Taskflow tf_;
 
-    RegInfo(const std::string & name) : tf_(name) {}
+    RegInfo(const std::string &name) : tf_(name) {}
   };
-
-
 
 private:
   void Initialize();

--- a/buildcc/lib/args/include/args/register.h
+++ b/buildcc/lib/args/include/args/register.h
@@ -73,8 +73,6 @@ public:
   // Getters
   const tf::Taskflow &GetTaskflow() const { return targets_.tf; }
 
-  std::string Graph() { return graphs_.tf.dump(); }
-
 private:
   struct TestInfo {
     base::Target &target_;
@@ -98,9 +96,6 @@ private:
   // Setup env:: defaults
   void Env();
 
-  void Dep(RegInfo &reginfo, const base::Target &target,
-           const base::Target &dependency);
-
   //
   tf::Task BuildTask(base::Target &target);
 
@@ -108,8 +103,6 @@ private:
   const Args &args_;
 
   RegInfo targets_{"Targets"};
-  RegInfo graphs_{"Graphs"};
-
   tf::Executor executor_;
 
   std::unordered_map<fs::path, TestInfo, internal::PathHash> tests_;

--- a/buildcc/lib/args/include/args/register.h
+++ b/buildcc/lib/args/include/args/register.h
@@ -71,7 +71,7 @@ public:
   void RunTest();
 
   // Getters
-  const tf::Taskflow &GetTaskflow() const { return deps_.tf_; }
+  const tf::Taskflow &GetTaskflow() const { return targets_.tf; }
 
 private:
   struct TestInfo {
@@ -84,10 +84,10 @@ private:
   };
 
   struct RegInfo {
-    std::unordered_map<fs::path, tf::Task, internal::PathHash> relation;
-    tf::Taskflow tf_;
+    std::unordered_map<fs::path, tf::Task, internal::PathHash> store;
+    tf::Taskflow tf;
 
-    RegInfo(const std::string &name) : tf_(name) {}
+    RegInfo(const std::string &name) : tf(name) {}
   };
 
 private:
@@ -102,7 +102,7 @@ private:
 private:
   const Args &args_;
 
-  RegInfo deps_{"Targets"};
+  RegInfo targets_{"Targets"};
 
   tf::Executor executor_;
 

--- a/buildcc/lib/args/include/args/register.h
+++ b/buildcc/lib/args/include/args/register.h
@@ -71,7 +71,7 @@ public:
   void RunTest();
 
   // Getters
-  const tf::Taskflow &GetTaskflow() const { return taskflow_; }
+  const tf::Taskflow &GetTaskflow() const { return deps_.tf_; }
 
 private:
   struct TestInfo {
@@ -82,6 +82,15 @@ private:
              const std::function<void(base::Target &target)> &cb)
         : target_(target), cb_(cb) {}
   };
+
+  struct RegInfo {
+    std::unordered_map<fs::path, tf::Task, internal::PathHash> relation;
+    tf::Taskflow tf_;
+
+    RegInfo(const std::string & name) : tf_(name) {}
+  };
+
+
 
 private:
   void Initialize();
@@ -94,11 +103,12 @@ private:
 
 private:
   const Args &args_;
+
+  RegInfo deps_{"Targets"};
+
   tf::Executor executor_;
-  tf::Taskflow taskflow_{"Targets"};
 
   std::unordered_map<fs::path, TestInfo, internal::PathHash> tests_;
-  std::unordered_map<fs::path, tf::Task, internal::PathHash> deps_;
 };
 
 } // namespace buildcc

--- a/buildcc/lib/args/include/args/register.h
+++ b/buildcc/lib/args/include/args/register.h
@@ -96,6 +96,9 @@ private:
   // Setup env:: defaults
   void Env();
 
+  void Dep(RegInfo &reginfo, const base::Target &target,
+           const base::Target &dependency);
+
   //
   tf::Task BuildTask(base::Target &target);
 
@@ -103,6 +106,7 @@ private:
   const Args &args_;
 
   RegInfo targets_{"Targets"};
+  RegInfo graphs_{"Graphs"};
 
   tf::Executor executor_;
 

--- a/buildcc/lib/args/mock/tasks.cpp
+++ b/buildcc/lib/args/mock/tasks.cpp
@@ -6,7 +6,7 @@ namespace buildcc {
 
 tf::Task Register::BuildTask(base::Target &target) {
   mock().actualCall(fmt::format("BuildTask_{}", target.GetName()).c_str());
-  return deps_.tf_.placeholder();
+  return targets_.tf.placeholder();
 }
 
 void Register::RunBuild() {}

--- a/buildcc/lib/args/mock/tasks.cpp
+++ b/buildcc/lib/args/mock/tasks.cpp
@@ -5,8 +5,12 @@
 namespace buildcc {
 
 tf::Task Register::BuildTask(base::Target &target) {
+  std::string targetpath = target.GetTargetPath()
+                               .lexically_relative(env::get_project_build_dir())
+                               .string();
+  std::replace(targetpath.begin(), targetpath.end(), '\\', '/');
   mock().actualCall(fmt::format("BuildTask_{}", target.GetName()).c_str());
-  return targets_.tf.placeholder();
+  return targets_.tf.placeholder().name(targetpath);
 }
 
 void Register::RunBuild() {}

--- a/buildcc/lib/args/mock/tasks.cpp
+++ b/buildcc/lib/args/mock/tasks.cpp
@@ -6,7 +6,7 @@ namespace buildcc {
 
 tf::Task Register::BuildTask(base::Target &target) {
   mock().actualCall(fmt::format("BuildTask_{}", target.GetName()).c_str());
-  return taskflow_.placeholder();
+  return deps_.tf_.placeholder();
 }
 
 void Register::RunBuild() {}

--- a/buildcc/lib/args/src/register.cpp
+++ b/buildcc/lib/args/src/register.cpp
@@ -40,16 +40,16 @@ void Register::Build(const Args::ToolchainState &toolchain_state,
     build_cb(target);
 
     tf::Task task = BuildTask(target);
-    deps_.relation.emplace(target.GetBinaryPath(), task);
+    targets_.store.emplace(target.GetBinaryPath(), task);
   }
 }
 
 void Register::Dep(const base::Target &target, const base::Target &dependency) {
   // target_task / dep_task cannot be empty
   // Either present or not found
-  const auto target_iter = deps_.relation.find(target.GetBinaryPath());
-  const auto dep_iter = deps_.relation.find(dependency.GetBinaryPath());
-  if (target_iter == deps_.relation.end() || dep_iter == deps_.relation.end()) {
+  const auto target_iter = targets_.store.find(target.GetBinaryPath());
+  const auto dep_iter = targets_.store.find(dependency.GetBinaryPath());
+  if (target_iter == targets_.store.end() || dep_iter == targets_.store.end()) {
     env::assert_fatal<false>("Call Register::Build API on target and "
                              "dependency before Register::Dep API");
   }
@@ -63,8 +63,8 @@ void Register::Test(const Args::ToolchainState &toolchain_state,
     return;
   }
 
-  const auto target_iter = deps_.relation.find(target.GetBinaryPath());
-  if (target_iter == deps_.relation.end()) {
+  const auto target_iter = targets_.store.find(target.GetBinaryPath());
+  if (target_iter == targets_.store.end()) {
     env::assert_fatal<false>(
         "Call Register::Build API on target before Register::Test API");
   }

--- a/buildcc/lib/args/src/register.cpp
+++ b/buildcc/lib/args/src/register.cpp
@@ -37,9 +37,9 @@ void Register::Build(const Args::ToolchainState &toolchain_state,
                      base::Target &target,
                      const std::function<void(base::Target &)> &build_cb) {
   if (toolchain_state.build) {
-    tf::Task task = BuildTask(target);
     build_cb(target);
-    // TODO, Add target.Build here
+
+    tf::Task task = BuildTask(target);
     deps_.relation.emplace(target.GetTargetPath(), task);
   }
 }

--- a/buildcc/lib/args/src/register.cpp
+++ b/buildcc/lib/args/src/register.cpp
@@ -40,16 +40,16 @@ void Register::Build(const Args::ToolchainState &toolchain_state,
     tf::Task task = BuildTask(target);
     build_cb(target);
     // TODO, Add target.Build here
-    deps_.insert({target.GetTargetPath(), task});
+    deps_.relation.emplace(target.GetTargetPath(), task);
   }
 }
 
 void Register::Dep(const base::Target &target, const base::Target &dependency) {
   // target_task / dep_task cannot be empty
   // Either present or not found
-  const auto target_iter = deps_.find(target.GetTargetPath());
-  const auto dep_iter = deps_.find(dependency.GetTargetPath());
-  if (target_iter == deps_.end() || dep_iter == deps_.end()) {
+  const auto target_iter = deps_.relation.find(target.GetTargetPath());
+  const auto dep_iter = deps_.relation.find(dependency.GetTargetPath());
+  if (target_iter == deps_.relation.end() || dep_iter == deps_.relation.end()) {
     env::assert_fatal<false>("Call Register::Build API on target and "
                              "dependency before Register::Dep API");
   }
@@ -63,8 +63,8 @@ void Register::Test(const Args::ToolchainState &toolchain_state,
     return;
   }
 
-  const auto target_iter = deps_.find(target.GetTargetPath());
-  if (target_iter == deps_.end()) {
+  const auto target_iter = deps_.relation.find(target.GetTargetPath());
+  if (target_iter == deps_.relation.end()) {
     env::assert_fatal<false>(
         "Call Register::Build API on target before Register::Test API");
   }

--- a/buildcc/lib/args/src/register.cpp
+++ b/buildcc/lib/args/src/register.cpp
@@ -59,12 +59,12 @@ void Register::Dep(RegInfo &reginfo, const base::Target &target,
   //  empty tasks -> not built so skip
   const auto target_iter = reginfo.store.find(target.GetBinaryPath());
   const auto dep_iter = reginfo.store.find(dependency.GetBinaryPath());
-  if (target_iter->second.empty() || dep_iter->second.empty()) {
-    return;
-  }
   if (target_iter == reginfo.store.end() || dep_iter == reginfo.store.end()) {
     env::assert_fatal<false>("Call Register::Build API on target and "
                              "dependency before Register::Dep API");
+  }
+  if (target_iter->second.empty() || dep_iter->second.empty()) {
+    return;
   }
   target_iter->second.succeed(dep_iter->second);
 }

--- a/buildcc/lib/args/src/register.cpp
+++ b/buildcc/lib/args/src/register.cpp
@@ -40,15 +40,15 @@ void Register::Build(const Args::ToolchainState &toolchain_state,
     build_cb(target);
 
     tf::Task task = BuildTask(target);
-    deps_.relation.emplace(target.GetTargetPath(), task);
+    deps_.relation.emplace(target.GetBinaryPath(), task);
   }
 }
 
 void Register::Dep(const base::Target &target, const base::Target &dependency) {
   // target_task / dep_task cannot be empty
   // Either present or not found
-  const auto target_iter = deps_.relation.find(target.GetTargetPath());
-  const auto dep_iter = deps_.relation.find(dependency.GetTargetPath());
+  const auto target_iter = deps_.relation.find(target.GetBinaryPath());
+  const auto dep_iter = deps_.relation.find(dependency.GetBinaryPath());
   if (target_iter == deps_.relation.end() || dep_iter == deps_.relation.end()) {
     env::assert_fatal<false>("Call Register::Build API on target and "
                              "dependency before Register::Dep API");
@@ -63,14 +63,14 @@ void Register::Test(const Args::ToolchainState &toolchain_state,
     return;
   }
 
-  const auto target_iter = deps_.relation.find(target.GetTargetPath());
+  const auto target_iter = deps_.relation.find(target.GetBinaryPath());
   if (target_iter == deps_.relation.end()) {
     env::assert_fatal<false>(
         "Call Register::Build API on target before Register::Test API");
   }
 
   const bool added =
-      tests_.emplace(target.GetTargetPath(), TestInfo(target, test_cb)).second;
+      tests_.emplace(target.GetBinaryPath(), TestInfo(target, test_cb)).second;
   env::assert_fatal(
       added, fmt::format("Could not register test {}", target.GetName()));
 }

--- a/buildcc/lib/args/src/register.cpp
+++ b/buildcc/lib/args/src/register.cpp
@@ -40,20 +40,39 @@ void Register::Build(const Args::ToolchainState &toolchain_state,
     build_cb(target);
 
     tf::Task task = BuildTask(target);
-    targets_.store.emplace(target.GetBinaryPath(), task);
+    const bool stored =
+        targets_.store.emplace(target.GetBinaryPath(), task).second;
+    env::assert_fatal(
+        stored, fmt::format("Could not register target {}", target.GetName()));
   }
+
+  tf::Task graph_task = graphs_.tf.placeholder().name(fmt::format(
+      "[{}] {}", target.GetToolchain().GetName(), target.GetName()));
+  const bool stored =
+      graphs_.store.emplace(target.GetBinaryPath(), graph_task).second;
+  env::assert_fatal(
+      stored, fmt::format("Could not register graph {}", target.GetName()));
 }
 
-void Register::Dep(const base::Target &target, const base::Target &dependency) {
+void Register::Dep(RegInfo &reginfo, const base::Target &target,
+                   const base::Target &dependency) {
   // target_task / dep_task cannot be empty
   // Either present or not found
-  const auto target_iter = targets_.store.find(target.GetBinaryPath());
-  const auto dep_iter = targets_.store.find(dependency.GetBinaryPath());
-  if (target_iter == targets_.store.end() || dep_iter == targets_.store.end()) {
+  const auto target_iter = reginfo.store.find(target.GetBinaryPath());
+  const auto dep_iter = reginfo.store.find(dependency.GetBinaryPath());
+  if (target_iter == reginfo.store.end() || dep_iter == reginfo.store.end()) {
     env::assert_fatal<false>("Call Register::Build API on target and "
                              "dependency before Register::Dep API");
   }
   target_iter->second.succeed(dep_iter->second);
+}
+
+void Register::Dep(const base::Target &target, const base::Target &dependency) {
+  // Target
+  Dep(targets_, target, dependency);
+
+  // Graph
+  Dep(graphs_, target, dependency);
 }
 
 void Register::Test(const Args::ToolchainState &toolchain_state,

--- a/buildcc/lib/args/src/tasks.cpp
+++ b/buildcc/lib/args/src/tasks.cpp
@@ -3,7 +3,11 @@
 namespace buildcc {
 
 tf::Task Register::BuildTask(base::Target &target) {
-  return targets_.tf.composed_of(target.GetTaskflow()).name("Task");
+  std::string targetpath = target.GetTargetPath()
+                               .lexically_relative(env::get_project_build_dir())
+                               .string();
+  std::replace(targetpath.begin(), targetpath.end(), '\\', '/');
+  return targets_.tf.composed_of(target.GetTaskflow()).name(targetpath);
 }
 
 void Register::RunBuild() {

--- a/buildcc/lib/args/src/tasks.cpp
+++ b/buildcc/lib/args/src/tasks.cpp
@@ -3,11 +3,11 @@
 namespace buildcc {
 
 tf::Task Register::BuildTask(base::Target &target) {
-  return deps_.tf_.composed_of(target.GetTaskflow()).name("Task");
+  return targets_.tf.composed_of(target.GetTaskflow()).name("Task");
 }
 
 void Register::RunBuild() {
-  executor_.run(deps_.tf_);
+  executor_.run(targets_.tf);
   executor_.wait_for_all();
 }
 

--- a/buildcc/lib/args/src/tasks.cpp
+++ b/buildcc/lib/args/src/tasks.cpp
@@ -3,11 +3,11 @@
 namespace buildcc {
 
 tf::Task Register::BuildTask(base::Target &target) {
-  return taskflow_.composed_of(target.GetTaskflow()).name("Task");
+  return deps_.tf_.composed_of(target.GetTaskflow()).name("Task");
 }
 
 void Register::RunBuild() {
-  executor_.run(taskflow_);
+  executor_.run(deps_.tf_);
   executor_.wait_for_all();
 }
 

--- a/buildcc/lib/args/test/test_register.cpp
+++ b/buildcc/lib/args/test/test_register.cpp
@@ -122,7 +122,7 @@ TEST(RegisterTestGroup, Register_Build) {
   mock().checkExpectations();
 }
 
-TEST(RegisterTestGroup, Register_Dep) {
+TEST(RegisterTestGroup, Register_BuildAndDep) {
   std::vector<const char *> av{
       "",
       "--config",
@@ -154,9 +154,9 @@ TEST(RegisterTestGroup, Register_Dep) {
   // 4 options
   // T -> Target
   // D -> Dep
-  // T0D0
-  // T0D1
-  // T1D0
+  // T0D0 -> Ignore
+  // T0D1 -> Ignore
+  // T1D0 -> Ignore
   // T1D1 -> This is the only condition for success
   buildcc::Args::ToolchainState falseState{false, false};
   buildcc::Args::ToolchainState trueState{true, true};
@@ -169,7 +169,7 @@ TEST(RegisterTestGroup, Register_Dep) {
     reg.Build(falseState, dependency,
               [](buildcc::base::Target &target) { (void)target; });
 
-    CHECK_THROWS(std::exception, reg.Dep(target, dependency));
+    reg.Dep(target, dependency);
   }
 
   // T0D1
@@ -181,7 +181,7 @@ TEST(RegisterTestGroup, Register_Dep) {
     reg.Build(trueState, dependency,
               [](buildcc::base::Target &target) { (void)target; });
 
-    CHECK_THROWS(std::exception, reg.Dep(target, dependency));
+    reg.Dep(target, dependency);
   }
 
   // T1D0
@@ -193,7 +193,7 @@ TEST(RegisterTestGroup, Register_Dep) {
     reg.Build(falseState, dependency,
               [](buildcc::base::Target &target) { (void)target; });
 
-    CHECK_THROWS(std::exception, reg.Dep(target, dependency));
+    reg.Dep(target, dependency);
   }
 
   // T1D1

--- a/buildcc/lib/args/test/test_register.cpp
+++ b/buildcc/lib/args/test/test_register.cpp
@@ -368,7 +368,77 @@ TEST(RegisterTestGroup, Register_DepDuplicate) {
   mock().checkExpectations();
 }
 
-TEST(RegisterTestGroup, Register_DepCyclic) {}
+TEST(RegisterTestGroup, Register_DepCyclic) {
+  std::vector<const char *> av{
+      "",
+      "--config",
+      "configs/basic_parse.toml",
+  };
+  int argc = av.size();
+
+  buildcc::Args args;
+  buildcc::Args::ToolchainArg gcc_toolchain;
+  buildcc::Args::ToolchainArg msvc_toolchain;
+  args.AddToolchain("gcc", "Generic gcc toolchain", gcc_toolchain);
+  args.AddToolchain("msvc", "Generic msvc toolchain", msvc_toolchain);
+  args.Parse(argc, av.data());
+
+  STRCMP_EQUAL(args.GetProjectRootDir().string().c_str(), "root");
+  STRCMP_EQUAL(args.GetProjectBuildDir().string().c_str(), "build");
+  CHECK(args.GetLogLevel() == buildcc::env::LogLevel::Trace);
+  CHECK_TRUE(args.Clean());
+
+  // Make dummy toolchain and target
+  buildcc::env::init(fs::current_path(), fs::current_path());
+  buildcc::base::Toolchain toolchain(buildcc::base::Toolchain::Id::Gcc, "", "",
+                                     "", "", "", "");
+  buildcc::base::Target target("dummyT", buildcc::base::TargetType::Executable,
+                               toolchain, "");
+  buildcc::base::Target dependency(
+      "depT", buildcc::base::TargetType::Executable, toolchain, "");
+  buildcc::base::Target dependency2(
+      "dep2T", buildcc::base::TargetType::Executable, toolchain, "");
+
+  buildcc::Args::ToolchainState trueState{true, true};
+
+  // Immediate cyclic depdendency
+  {
+    buildcc::Register reg(args);
+    mock().expectNCalls(1, "BuildTask_dummyT");
+    mock().expectNCalls(1, "BuildTask_depT");
+    reg.Build(trueState, target,
+              [](buildcc::base::Target &target) { (void)target; });
+    reg.Build(trueState, dependency,
+              [](buildcc::base::Target &target) { (void)target; });
+
+    reg.Dep(target, dependency);
+    CHECK_THROWS(std::exception, reg.Dep(dependency, target));
+  }
+
+  // Duplicate dependency with 3 Targets
+  {
+    buildcc::Register reg(args);
+    mock().expectNCalls(1, "BuildTask_dummyT");
+    mock().expectNCalls(1, "BuildTask_depT");
+    mock().expectNCalls(1, "BuildTask_dep2T");
+
+    reg.Build(trueState, target,
+              [](buildcc::base::Target &target) { (void)target; });
+    reg.Build(trueState, dependency,
+              [](buildcc::base::Target &target) { (void)target; });
+    reg.Build(trueState, dependency2,
+              [](buildcc::base::Target &target) { (void)target; });
+
+    reg.Dep(dependency, dependency2);
+    reg.Dep(target, dependency);
+
+    // dependency2 -> dependency -> target -> dependency2
+    CHECK_THROWS(std::exception, reg.Dep(dependency2, target));
+  }
+
+  buildcc::env::deinit();
+  mock().checkExpectations();
+}
 
 TEST(RegisterTestGroup, Register_Test) {
   // Arguments


### PR DESCRIPTION
- Added `Register::Dep` updates
  - Detect duplicate deps (immediate)
  - Detect cyclic dependency (complete/nested)
- Added RegInfo pairing
- [Fix] `Register::Dep` causes crash when `state.build == false` during `Register::Build`
  - This happens when multiple toolchains are added but only few targets are built
-  [Fix] Change store detection to `GetBinaryPath` from `GetTargetPath`