### PR TITLE
[Plugin] BuildCC Find

### DIFF
--- a/buildcc/lib/args/src/parse.cpp
+++ b/buildcc/lib/args/src/parse.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Niket Naidu. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "args/args.h"
 
 namespace buildcc {

--- a/buildcc/lib/args/src/tasks.cpp
+++ b/buildcc/lib/args/src/tasks.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Niket Naidu. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "args/register.h"
 
 namespace buildcc {

--- a/buildcc/lib/env/src/assert_fatal.cpp
+++ b/buildcc/lib/env/src/assert_fatal.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Niket Naidu. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "env/assert_fatal.h"
 
 #include <exception>

--- a/buildcc/plugins/CMakeLists.txt
+++ b/buildcc/plugins/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(PLUGINS_SRCS
     src/clang_compile_commands.cpp
+    src/buildcc_find.cpp
     include/plugins/clang_compile_commands.h
+    include/plugins/buildcc_find.h
 )
 
 if(${BUILDCC_BUILD_AS_SINGLE_LIB})

--- a/buildcc/plugins/CMakeLists.txt
+++ b/buildcc/plugins/CMakeLists.txt
@@ -1,3 +1,39 @@
+# Plugin test
+if (${TESTING})
+add_library(mock_plugins
+    src/buildcc_find.cpp
+)
+target_include_directories(mock_plugins PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+target_compile_options(mock_plugins PUBLIC 
+    ${TEST_COMPILE_FLAGS} ${BUILD_COMPILE_FLAGS}
+)
+target_link_options(mock_plugins PUBLIC 
+    ${TEST_LINK_FLAGS} ${BUILD_LINK_FLAGS}
+)
+target_link_libraries(mock_plugins PUBLIC 
+    mock_target
+
+    CppUTest
+    CppUTestExt
+    gcov
+)
+
+# Tests
+add_executable(test_buildcc_find
+    test/test_buildcc_find.cpp
+)
+target_link_libraries(test_buildcc_find PRIVATE
+    mock_plugins
+)
+
+add_test(NAME test_buildcc_find COMMAND test_buildcc_find
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test
+)
+
+endif()
+
 set(PLUGINS_SRCS
     src/clang_compile_commands.cpp
     src/buildcc_find.cpp

--- a/buildcc/plugins/include/plugins/buildcc_find.h
+++ b/buildcc/plugins/include/plugins/buildcc_find.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Niket Naidu. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLUGINS_BUILDCC_FIND_H_
+#define PLUGINS_BUILDCC_FIND_H_
+
+#include <filesystem>
+#include <initializer_list>
+#include <string>
+
+#include "env/host_os.h"
+
+#include "fmt/format.h"
+
+namespace fs = std::filesystem;
+
+namespace buildcc::plugin {
+
+/**
+ * @brief By default searched the `PATH` environment variable for required
+ * package
+ *
+ */
+// TODO, Add support for regex matching
+class BuildccFind {
+public:
+  // TODO, Add more
+  enum class Type {
+    HostExecutable,
+    BuildccLibrary,
+    BuildccPlugin,
+  };
+
+public:
+  BuildccFind(const std::string &regex, Type type,
+              std::initializer_list<std::string> host_env_vars = {})
+      : regex_(regex), type_(type), host_env_vars_(host_env_vars) {
+    if constexpr (env::is_win()) {
+      regex_ = fmt::format("{}.exe", regex);
+    }
+  }
+  BuildccFind(const BuildccFind &) = delete;
+
+  void AddHostEnvVar(const std::string &host_env_var) {
+    host_env_vars_.push_back(host_env_var);
+  }
+  void AddHostEnvVars(std::initializer_list<std::string> host_env_vars) {
+    for (const auto &ev : host_env_vars) {
+      AddHostEnvVar(ev);
+    }
+  }
+
+  /**
+   * @brief Starts the search for package of type and name
+   *
+   */
+  bool Search();
+
+  //   Getters
+  const std::vector<fs::path> &GetPathMatches() { return target_matches_; }
+
+private:
+  bool SearchHostExecutable();
+
+private:
+  std::string regex_;
+  Type type_;
+
+  std::vector<std::string> host_env_vars_;
+
+  std::vector<fs::path> target_matches_;
+};
+
+} // namespace buildcc::plugin
+
+#endif

--- a/buildcc/plugins/src/buildcc_find.cpp
+++ b/buildcc/plugins/src/buildcc_find.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2021 Niket Naidu. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plugins/buildcc_find.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <regex>
+
+#include "env/logging.h"
+
+#include "target/path.h"
+
+namespace {
+constexpr const char *const kEnvVarNotFound =
+    "{} environment variable not found";
+constexpr const char *const kOsNotSupported =
+    "Search functionality does not support this operating system. Raise an "
+    "issue at https://github.com/coder137/build_in_cpp outlining your OS and "
+    "usecase";
+
+// Windows
+constexpr const char *const kWinEnvDelim = ";";
+
+// Linux
+constexpr const char *const kLinuxEnvDelim = ":";
+
+// TODO, Add Environment Variable delimiters for more operating systems
+// ; for windows
+// : for linux
+constexpr const char *const GetEnvVarDelim() {
+  if constexpr (buildcc::env::is_win()) {
+    return kWinEnvDelim;
+  } else if constexpr (buildcc::env::is_linux()) {
+    return kLinuxEnvDelim;
+  }
+
+  return nullptr;
+}
+
+std::vector<fs::path> SplitEnv(const char *env_ptr, const char *delim) {
+  std::vector<fs::path> env_paths;
+
+  std::string temp{env_ptr};
+  char *path = std::strtok(temp.data(), delim);
+  while (path != nullptr) {
+    env_paths.push_back(
+        buildcc::internal::Path::CreateNewPath(path).GetPathname());
+    path = std::strtok(nullptr, delim);
+  }
+
+  return env_paths;
+}
+
+std::vector<fs::path> SearchEnv(const std::string &host_env_var,
+                                const std::string &regex) {
+  char *path_ptr = std::getenv(host_env_var.c_str());
+  if (path_ptr == nullptr) {
+    buildcc::env::log_critical(__FUNCTION__,
+                               fmt::format(kEnvVarNotFound, host_env_var));
+    return {};
+  }
+
+  std::vector<fs::path> env_paths;
+  constexpr const char *const kDelim = GetEnvVarDelim();
+  if constexpr (kDelim == nullptr) {
+    buildcc::env::log_critical(__FUNCTION__, kOsNotSupported);
+    return {};
+  }
+  env_paths = SplitEnv(path_ptr, kDelim);
+
+  // DONE, Construct a directory iterator
+  // Only take the files
+  std::vector<fs::path> matches;
+  for (const auto &env_p : env_paths) {
+    std::error_code errcode;
+    const auto dir_iter = fs::directory_iterator(env_p, errcode);
+    if (errcode) {
+      buildcc::env::log_critical(env_p.string(), errcode.message());
+      continue;
+    }
+
+    for (const auto &dir_entry : dir_iter) {
+      if (!dir_entry.is_regular_file()) {
+        continue;
+      }
+
+      // Compare name_ with filename
+      std::string filename = dir_entry.path().filename().string();
+      bool match = std::regex_match(filename, std::regex(regex));
+      if (match) {
+        matches.push_back(dir_entry.path());
+      }
+    }
+  }
+
+  return matches;
+}
+
+} // namespace
+
+namespace buildcc::plugin {
+
+// Public
+
+bool BuildccFind::Search() {
+  switch (type_) {
+  case Type::HostExecutable:
+    return SearchHostExecutable();
+    break;
+  case Type::BuildccLibrary:
+  case Type::BuildccPlugin:
+  default:
+    // TODO, Add this functionality
+    break;
+  }
+
+  return false;
+}
+
+// Private
+
+bool BuildccFind::SearchHostExecutable() {
+  for (const auto &ev : host_env_vars_) {
+    std::vector<fs::path> matches = SearchEnv(ev, regex_);
+    target_matches_.insert(target_matches_.end(), matches.begin(),
+                           matches.end());
+  }
+
+  // TODO,
+  // for (const auto &asp : absolute_search_paths_) {
+  // }
+
+  return !target_matches_.empty();
+}
+
+} // namespace buildcc::plugin

--- a/buildcc/plugins/src/buildcc_find.cpp
+++ b/buildcc/plugins/src/buildcc_find.cpp
@@ -140,10 +140,6 @@ bool BuildccFind::SearchHostExecutable() {
                            matches.end());
   }
 
-  // TODO,
-  // for (const auto &asp : absolute_search_paths_) {
-  // }
-
   return !target_matches_.empty();
 }
 

--- a/buildcc/plugins/test/test_buildcc_find.cpp
+++ b/buildcc/plugins/test/test_buildcc_find.cpp
@@ -33,6 +33,39 @@ TEST(PluginsTestGroup, BuildccFind_BadEnv) {
   CHECK_TRUE(matches.empty());
 }
 
+TEST(PluginsTestGroup, BuildccFind_WrongExecutable) {
+  buildcc::plugin::BuildccFind findrandomexecutable(
+      "random_cmake_executable",
+      buildcc::plugin::BuildccFind::Type::HostExecutable, {"FIND_RANDOM_ENV"});
+  bool found = findrandomexecutable.Search();
+  CHECK_FALSE(found);
+
+  const std::vector<fs::path> &matches = findrandomexecutable.GetPathMatches();
+  CHECK_TRUE(matches.empty());
+}
+
+TEST(PluginsTestGroup, BuildccFind_SearchUnimplemented) {
+  {
+    buildcc::plugin::BuildccFind findunimplemented(
+        "random_library", buildcc::plugin::BuildccFind::Type::BuildccLibrary);
+    bool found = findunimplemented.Search();
+    CHECK_FALSE(found);
+
+    const std::vector<fs::path> &matches = findunimplemented.GetPathMatches();
+    CHECK_TRUE(matches.empty());
+  }
+
+  {
+    buildcc::plugin::BuildccFind findunimplemented(
+        "random_library", buildcc::plugin::BuildccFind::Type::BuildccPlugin);
+    bool found = findunimplemented.Search();
+    CHECK_FALSE(found);
+
+    const std::vector<fs::path> &matches = findunimplemented.GetPathMatches();
+    CHECK_TRUE(matches.empty());
+  }
+}
+
 int main(int ac, char **av) {
   return CommandLineTestRunner::RunAllTests(ac, av);
 }

--- a/buildcc/plugins/test/test_buildcc_find.cpp
+++ b/buildcc/plugins/test/test_buildcc_find.cpp
@@ -18,11 +18,20 @@ TEST(PluginsTestGroup, BuildccFind_Search) {
   bool found = findcmake.Search();
   CHECK_TRUE(found);
 
-  std::vector<fs::path> matches = findcmake.GetPathMatches();
+  const std::vector<fs::path> &matches = findcmake.GetPathMatches();
   CHECK_TRUE(!matches.empty());
 }
 
-TEST(PluginsTestGroup, BuildccFind_BadEnv) {}
+TEST(PluginsTestGroup, BuildccFind_BadEnv) {
+  buildcc::plugin::BuildccFind findrandomenv(
+      "cmake", buildcc::plugin::BuildccFind::Type::HostExecutable,
+      {"FIND_RANDOM_ENV"});
+  bool found = findrandomenv.Search();
+  CHECK_FALSE(found);
+
+  const std::vector<fs::path> &matches = findrandomenv.GetPathMatches();
+  CHECK_TRUE(matches.empty());
+}
 
 int main(int ac, char **av) {
   return CommandLineTestRunner::RunAllTests(ac, av);

--- a/buildcc/plugins/test/test_buildcc_find.cpp
+++ b/buildcc/plugins/test/test_buildcc_find.cpp
@@ -1,0 +1,29 @@
+#include "plugins/buildcc_find.h"
+
+// NOTE, Make sure all these includes are AFTER the system and header includes
+#include "CppUTest/CommandLineTestRunner.h"
+#include "CppUTest/MemoryLeakDetectorNewMacros.h"
+#include "CppUTest/TestHarness.h"
+#include "CppUTest/Utest.h"
+
+// clang-format off
+TEST_GROUP(PluginsTestGroup)
+{
+};
+// clang-format on
+
+TEST(PluginsTestGroup, BuildccFind_Search) {
+  buildcc::plugin::BuildccFind findcmake(
+      "cmake", buildcc::plugin::BuildccFind::Type::HostExecutable, {"PATH"});
+  bool found = findcmake.Search();
+  CHECK_TRUE(found);
+
+  std::vector<fs::path> matches = findcmake.GetPathMatches();
+  CHECK_TRUE(!matches.empty());
+}
+
+TEST(PluginsTestGroup, BuildccFind_BadEnv) {}
+
+int main(int ac, char **av) {
+  return CommandLineTestRunner::RunAllTests(ac, av);
+}


### PR DESCRIPTION
- Find host executable dependending on regex. 
- Traverses host environment variable to find executables
- Stores location of multiple matched executables