### PR TITLE
Decouple input source from output object

### DIFF
--- a/buildcc/lib/target/include/target/friend/compile_object.h
+++ b/buildcc/lib/target/include/target/friend/compile_object.h
@@ -44,8 +44,7 @@ public:
 public:
   CompileObject(Target &target) : target_(target) {}
 
-  void AddObjectData(const fs::path &absolute_source_path,
-                     const fs::path &absolute_object_path);
+  void AddObjectData(const fs::path &absolute_source_path);
 
   void CacheCompileCommands();
   void Task();
@@ -59,6 +58,8 @@ public:
   tf::Task &GetTask() { return compile_task_; }
 
 private:
+  fs::path ConstructObjectPath(const fs::path &absolute_source_file) const;
+
   void BuildObjectCompile(std::vector<fs::path> &source_files,
                           std::vector<fs::path> &dummy_source_files);
 

--- a/buildcc/lib/target/include/target/target.h
+++ b/buildcc/lib/target/include/target/target.h
@@ -369,9 +369,6 @@ private:
   void FlagChanged();
   void ExternalLibChanged();
 
-  // Construct
-  fs::path ConstructObjectPath(const fs::path &absolute_source_file) const;
-
   void TaskDeps();
 
 private:

--- a/buildcc/lib/target/include/target/target.h
+++ b/buildcc/lib/target/include/target/target.h
@@ -175,10 +175,8 @@ public:
 
   // Use these APIs for out of project root builds
   // Manually specify input and output
-  void AddSourceAbsolute(const fs::path &absolute_input_filepath,
-                         const fs::path &absolute_output_filepath);
-  void GlobSourcesAbsolute(const fs::path &absolute_input_path,
-                           const fs::path &absolute_output_path);
+  void AddSourceAbsolute(const fs::path &absolute_input_filepath);
+  void GlobSourcesAbsolute(const fs::path &absolute_input_path);
 
   // * Headers
   void AddHeader(const fs::path &relative_filename,
@@ -382,7 +380,6 @@ private:
   Type type_;
   const Toolchain &toolchain_;
   Config config_;
-
   Env env_;
   internal::TargetLoader loader_;
 

--- a/buildcc/lib/target/src/target/build.cpp
+++ b/buildcc/lib/target/src/target/build.cpp
@@ -57,7 +57,18 @@ void Target::Build() {
   LockedAfterBuild();
   Lock();
 
-  // Taskflow updates
+  // Source - Object relation
+  // Source state
+  for (const auto &abs_source : storer_.current_source_files.user) {
+    // Set state
+    const auto file_ext_type = ext_.GetType(abs_source);
+    ext_.SetSourceState(file_ext_type);
+
+    // Relate input source with output object
+    compile_object_.AddObjectData(abs_source);
+  }
+
+  // Target default arguments
   command_.AddDefaultArguments({
       {kIncludeDirs, internal::aggregate_with_prefix(config_.prefix_include_dir,
                                                      GetCurrentIncludeDirs())},
@@ -99,16 +110,6 @@ void Target::Build() {
   }
 
   // Compile Command
-
-  // Relate input source files with output object files
-  for (const auto &abs_source : storer_.current_source_files.user) {
-    // Set state
-    const auto file_ext_type = ext_.GetType(abs_source);
-    ext_.SetSourceState(file_ext_type);
-
-    // Relate input source with output object
-    compile_object_.AddObjectData(abs_source);
-  }
   compile_object_.CacheCompileCommands();
   compile_object_.Task();
 

--- a/buildcc/lib/target/src/target/build.cpp
+++ b/buildcc/lib/target/src/target/build.cpp
@@ -107,9 +107,7 @@ void Target::Build() {
     ext_.SetSourceState(file_ext_type);
 
     // Relate input source with output object
-    const auto abs_object = ConstructObjectPath(abs_source);
-    fs::create_directories(abs_object.parent_path());
-    compile_object_.AddObjectData(abs_source, abs_object);
+    compile_object_.AddObjectData(abs_source);
   }
   compile_object_.CacheCompileCommands();
   compile_object_.Task();

--- a/buildcc/lib/target/src/target/build.cpp
+++ b/buildcc/lib/target/src/target/build.cpp
@@ -99,6 +99,18 @@ void Target::Build() {
   }
 
   // Compile Command
+
+  // Relate input source files with output object files
+  for (const auto &abs_source : storer_.current_source_files.user) {
+    // Set state
+    const auto file_ext_type = ext_.GetType(abs_source);
+    ext_.SetSourceState(file_ext_type);
+
+    // Relate input source with output object
+    const auto abs_object = ConstructObjectPath(abs_source);
+    fs::create_directories(abs_object.parent_path());
+    compile_object_.AddObjectData(abs_source, abs_object);
+  }
   compile_object_.CacheCompileCommands();
   compile_object_.Task();
 

--- a/buildcc/lib/target/src/target/copy.cpp
+++ b/buildcc/lib/target/src/target/copy.cpp
@@ -79,9 +79,8 @@ void Target::Copy(const Target &target,
               [&](const auto &f) { AddLinkDependency(f); });
       break;
     case CopyOption::SourceFiles:
-      CopyVar(target.compile_object_.GetObjectDataMap(), [&](const auto &m) {
-        AddSourceAbsolute(m.first, m.second.output);
-      });
+      CopyVar(target.storer_.current_source_files.user,
+              [&](const auto &f) { AddSourceAbsolute(f); });
       break;
     case CopyOption::HeaderFiles:
       CopyVar(target.storer_.current_header_files.user,

--- a/buildcc/lib/target/src/target/source.cpp
+++ b/buildcc/lib/target/src/target/source.cpp
@@ -25,36 +25,23 @@
 namespace buildcc::base {
 
 // Public
-void Target::AddSourceAbsolute(const fs::path &absolute_input_filepath,
-                               const fs::path &absolute_output_filepath) {
+void Target::AddSourceAbsolute(const fs::path &absolute_input_filepath) {
   LockedAfterBuild();
   const auto file_ext_type = ext_.GetType(absolute_input_filepath);
   env::assert_fatal(FileExt::IsValidSource(file_ext_type),
                     fmt::format("{} does not have a valid source extension",
                                 absolute_input_filepath));
-  ext_.SetSourceState(file_ext_type);
 
   const fs::path absolute_source =
       fs::path(absolute_input_filepath).make_preferred();
   storer_.current_source_files.user.insert(absolute_source);
-
-  // Relate input source files with output object files
-  const auto absolute_compiled_source =
-      fs::path(absolute_output_filepath).make_preferred();
-  fs::create_directories(absolute_compiled_source.parent_path());
-
-  compile_object_.AddObjectData(absolute_source, absolute_compiled_source);
 }
 
-void Target::GlobSourcesAbsolute(const fs::path &absolute_input_path,
-                                 const fs::path &absolute_output_path) {
+void Target::GlobSourcesAbsolute(const fs::path &absolute_input_path) {
   for (const auto &p : fs::directory_iterator(absolute_input_path)) {
     const auto file_ext_type = ext_.GetType(p.path());
     if (FileExt::IsValidSource(file_ext_type)) {
-      fs::path absolute_output_source =
-          absolute_output_path /
-          fmt::format("{}{}", p.path().filename().string(), config_.obj_ext);
-      AddSourceAbsolute(p.path(), absolute_output_source);
+      AddSourceAbsolute(p.path());
     }
   }
 }
@@ -67,7 +54,7 @@ void Target::AddSource(const fs::path &relative_filename,
   fs::path absolute_source =
       GetTargetRootDir() / relative_to_target_path / relative_filename;
 
-  AddSourceAbsolute(absolute_source, ConstructObjectPath(absolute_source));
+  AddSourceAbsolute(absolute_source);
 }
 
 void Target::GlobSources(const fs::path &relative_to_target_path) {
@@ -78,7 +65,7 @@ void Target::GlobSources(const fs::path &relative_to_target_path) {
   for (const auto &p : fs::directory_iterator(absolute_input_path)) {
     const auto file_ext_type = ext_.GetType(p.path());
     if (FileExt::IsValidSource(file_ext_type)) {
-      AddSourceAbsolute(p.path(), ConstructObjectPath(p.path()));
+      AddSourceAbsolute(p.path());
     }
   }
 }

--- a/buildcc/lib/target/src/target/source.cpp
+++ b/buildcc/lib/target/src/target/source.cpp
@@ -70,35 +70,28 @@ void Target::GlobSources(const fs::path &relative_to_target_path) {
   }
 }
 
-fs::path
-Target::ConstructObjectPath(const fs::path &absolute_source_file) const {
-  // Compute the relative compiled source path
-  fs::path relative =
-      absolute_source_file.lexically_relative(env::get_project_root_dir());
+// fs::path
+// Target::ConstructObjectPath(const fs::path &absolute_source_file) const {
+//   // Compute the relative compiled source path
+//   fs::path relative =
+//       absolute_source_file.lexically_relative(GetTargetRootDir());
 
-  // - Check if out of root
-  // - Convert .. to __
-  // NOTE, Similar to how CMake handles out of root files
-  std::string relstr = relative.string();
-  if (relstr.find("..") != std::string::npos) {
-    // TODO, If unnecessary, remove this warning
-    env::log_warning(
-        name_,
-        fmt::format("Out of project root path detected for {} -> "
-                    "{}.\nConverting .. to __ but it is recommended to use the "
-                    "AddSourceAbsolute(abs_source_input, abs_obj_output) or "
-                    "GlobSourceAbsolute(abs_source_input, abs_obj_output) "
-                    "API if possible.",
-                    absolute_source_file, relative));
-    std::replace(relstr.begin(), relstr.end(), '.', '_');
-    relative = relstr;
-  }
+//   // TODO, Add path replacement strategy on relative
 
-  // Compute relative object path
-  fs::path absolute_compiled_source = GetTargetBuildDir() / relative;
-  absolute_compiled_source.replace_filename(fmt::format(
-      "{}{}", absolute_source_file.filename().string(), config_.obj_ext));
-  return absolute_compiled_source;
-}
+//   // - Check if out of root
+//   // - Convert .. to __
+//   // NOTE, Similar to how CMake handles out of root files
+//   std::string relstr = relative.string();
+//   if (relstr.find("..") != std::string::npos) {
+//     std::replace(relstr.begin(), relstr.end(), '.', '_');
+//     relative = relstr;
+//   }
+
+//   // Compute relative object path
+//   fs::path absolute_compiled_source = GetTargetBuildDir() / relative;
+//   absolute_compiled_source.replace_filename(fmt::format(
+//       "{}{}", absolute_source_file.filename().string(), config_.obj_ext));
+//   return absolute_compiled_source;
+// }
 
 } // namespace buildcc::base

--- a/buildcc/lib/target/test/target/test_target_source_out_of_root.cpp
+++ b/buildcc/lib/target/test/target/test_target_source_out_of_root.cpp
@@ -73,10 +73,8 @@ TEST(TargetTestSourceOutOfRootGroup, GlobAbsolute_OutOfRootSource) {
   {
     buildcc::base::Target simple(
         OUTOFROOT, buildcc::base::Target::Type::Executable, gcc, "");
-    simple.GlobSourcesAbsolute(fs::path(BUILD_SCRIPT_SOURCE) / "data",
-                               target_source_intermediate_path /
-                                   simple.GetName() /
-                                   "OUT_OF_SOURCE"); // 6 files detected
+    simple.GlobSourcesAbsolute(fs::path(BUILD_SCRIPT_SOURCE) /
+                               "data"); // 6 files detected
     buildcc::m::CommandExpect_Execute(6, true);
     buildcc::m::CommandExpect_Execute(1, true);
     simple.Build();


### PR DESCRIPTION
Output object is now constructed during `Target::Build` instead of during every `Target::AddSource*` call