### PR TITLE
Target Info

### DIFF
--- a/buildcc/lib/target/cmake/mock_target.cmake
+++ b/buildcc/lib/target/cmake/mock_target.cmake
@@ -7,13 +7,17 @@ add_library(mock_target STATIC
     src/common/target_state.cpp
 
     # API
-    src/api/copy_api.cpp
     src/api/source_api.cpp
     src/api/include_api.cpp
     src/api/lib_api.cpp
     src/api/pch_api.cpp
     src/api/flag_api.cpp
     src/api/deps_api.cpp
+
+    src/api/copy_api.cpp
+
+    src/api/target_info_getter.cpp
+
 
     # Generator
     src/generator/generator_loader.cpp

--- a/buildcc/lib/target/cmake/target.cmake
+++ b/buildcc/lib/target/cmake/target.cmake
@@ -18,20 +18,24 @@ set(TARGET_SRCS
     include/target/common/target_type.h
 
     # API
-    src/api/copy_api.cpp
     src/api/source_api.cpp
     src/api/include_api.cpp
     src/api/lib_api.cpp
     src/api/pch_api.cpp
     src/api/flag_api.cpp
     src/api/deps_api.cpp
-    include/target/api/copy_api.h
     include/target/api/source_api.h
     include/target/api/include_api.h
     include/target/api/lib_api.h
     include/target/api/pch_api.h
     include/target/api/flag_api.h
     include/target/api/deps_api.h
+
+    src/api/copy_api.cpp
+    include/target/api/copy_api.h
+    
+    src/api/target_info_getter.cpp
+    include/target/api/target_info_getter.h
 
     # Generator
     src/generator/generator_loader.cpp

--- a/buildcc/lib/target/include/target/api/target_info_getter.h
+++ b/buildcc/lib/target/include/target/api/target_info_getter.h
@@ -19,6 +19,7 @@
 
 #include "target/path.h"
 
+#include "target/common/target_config.h"
 #include "target/common/target_state.h"
 
 namespace buildcc::base {
@@ -26,12 +27,21 @@ namespace buildcc::base {
 // Requires
 // - TargetStorer
 // - TargetState
+// - TargetEnv
+// - TargetConfig
 template <typename T> class TargetInfoGetter {
 public:
   // Target State
   const TargetState &GetState() const;
   bool GetBuildState() const;
   bool GetLockState() const;
+
+  // Target Env
+  const fs::path &GetTargetRootDir() const;
+  const fs::path &GetTargetBuildDir() const;
+
+  // Target Config
+  const TargetConfig &GetConfig() const;
 
   // Target Storer
   const internal::fs_unordered_set &GetCurrentSourceFiles() const;

--- a/buildcc/lib/target/include/target/api/target_info_getter.h
+++ b/buildcc/lib/target/include/target/api/target_info_getter.h
@@ -33,7 +33,7 @@ public:
   bool GetBuildState() const;
   bool GetLockState() const;
 
-  // Target Storere
+  // Target Storer
   const internal::fs_unordered_set &GetCurrentSourceFiles() const;
   const internal::fs_unordered_set &GetCurrentHeaderFiles() const;
   const internal::fs_unordered_set &GetCurrentPchFiles() const;

--- a/buildcc/lib/target/include/target/api/target_info_getter.h
+++ b/buildcc/lib/target/include/target/api/target_info_getter.h
@@ -19,12 +19,21 @@
 
 #include "target/path.h"
 
+#include "target/common/target_state.h"
+
 namespace buildcc::base {
 
 // Requires
 // - TargetStorer
+// - TargetState
 template <typename T> class TargetInfoGetter {
 public:
+  // Target State
+  const TargetState &GetState() const;
+  bool GetBuildState() const;
+  bool GetLockState() const;
+
+  // Target Storere
   const internal::fs_unordered_set &GetCurrentSourceFiles() const;
   const internal::fs_unordered_set &GetCurrentHeaderFiles() const;
   const internal::fs_unordered_set &GetCurrentPchFiles() const;

--- a/buildcc/lib/target/include/target/api/target_info_getter.h
+++ b/buildcc/lib/target/include/target/api/target_info_getter.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Niket Naidu. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TARGET_API_TARGET_INFO_GETTER_H_
+#define TARGET_API_TARGET_INFO_GETTER_H_
+
+#include "target/path.h"
+
+namespace buildcc::base {
+
+// Requires
+// - TargetStorer
+template <typename T> class TargetInfoGetter {
+public:
+  const internal::fs_unordered_set &GetCurrentSourceFiles() const;
+  const internal::fs_unordered_set &GetCurrentHeaderFiles() const;
+  const internal::fs_unordered_set &GetCurrentPchFiles() const;
+  const internal::fs_unordered_set &GetTargetLibDeps() const;
+  const std::unordered_set<std::string> &GetCurrentExternalLibDeps() const;
+  const internal::fs_unordered_set &GetCurrentIncludeDirs() const;
+  const internal::fs_unordered_set &GetCurrentLibDirs() const;
+  const std::unordered_set<std::string> &GetCurrentPreprocessorFlags() const;
+  const std::unordered_set<std::string> &GetCurrentCommonCompileFlags() const;
+  const std::unordered_set<std::string> &GetCurrentPchCompileFlags() const;
+  const std::unordered_set<std::string> &GetCurrentPchObjectFlags() const;
+  const std::unordered_set<std::string> &GetCurrentAsmCompileFlags() const;
+  const std::unordered_set<std::string> &GetCurrentCCompileFlags() const;
+  const std::unordered_set<std::string> &GetCurrentCppCompileFlags() const;
+  const std::unordered_set<std::string> &GetCurrentLinkFlags() const;
+  const internal::fs_unordered_set &GetCurrentCompileDependencies() const;
+  const internal::fs_unordered_set &GetCurrentLinkDependencies() const;
+};
+
+} // namespace buildcc::base
+
+#endif

--- a/buildcc/lib/target/include/target/common/target_state.h
+++ b/buildcc/lib/target/include/target/common/target_state.h
@@ -22,6 +22,10 @@
 namespace buildcc::base {
 
 // TODO, Seperate TargetState into lock_ and other internal boolean variables
+// NOTE, This is because apart from lock_ every other parameter is updated
+// during `Target::Build`
+// TargetInfo does not have a `Build` method, it is only meant to hold
+// information
 struct TargetState {
   void SetSourceState(TargetFileExt file_extension);
   void SetPch();
@@ -29,14 +33,9 @@ struct TargetState {
 
   void ExpectsUnlock() const;
   void ExpectsLock() const;
+  // TODO, IsLocked
 
   bool ContainsPch() const { return contains_pch_; }
-  // TODO, ContainsAsm
-  // TODO, ContainsC
-  // TODO, ContainsCpp
-
-  // TODO, IsLocked
-  // TODO, IsBuilt
 
   // TODO, Make these private getters
   bool contains_asm{false};

--- a/buildcc/lib/target/include/target/common/target_state.h
+++ b/buildcc/lib/target/include/target/common/target_state.h
@@ -21,6 +21,7 @@
 
 namespace buildcc::base {
 
+// TODO, Seperate TargetState into lock_ and other internal boolean variables
 struct TargetState {
   void SetSourceState(TargetFileExt file_extension);
   void SetPch();

--- a/buildcc/lib/target/include/target/target.h
+++ b/buildcc/lib/target/include/target/target.h
@@ -100,9 +100,6 @@ public:
   const std::string &GetName() const { return name_; }
   const Toolchain &GetToolchain() const { return toolchain_; }
   TargetType GetType() const { return type_; }
-  const fs::path &GetTargetRootDir() const { return env_.GetTargetRootDir(); }
-  const fs::path &GetTargetBuildDir() const { return env_.GetTargetBuildDir(); }
-  const TargetConfig &GetConfig() const { return config_; }
 
   //
 

--- a/buildcc/lib/target/include/target/target.h
+++ b/buildcc/lib/target/include/target/target.h
@@ -83,11 +83,7 @@ public:
   // Builders
   void Build() override;
 
-  // TODO, Add more setters
-
   // Getters (GENERIC)
-
-  // Target state
 
   // Set during first build or rebuild
   // lock == true after Build is called
@@ -117,57 +113,6 @@ public:
   const TargetConfig &GetConfig() const { return config_; }
 
   //
-  const internal::fs_unordered_set &GetCurrentSourceFiles() const {
-    return storer_.current_source_files.user;
-  }
-  const internal::fs_unordered_set &GetCurrentHeaderFiles() const {
-    return storer_.current_header_files.user;
-  }
-  const internal::fs_unordered_set &GetCurrentPchFiles() const {
-    return storer_.current_pch_files.user;
-  }
-  const internal::fs_unordered_set &GetTargetLibDeps() const {
-    return storer_.current_lib_deps.user;
-  }
-  const std::unordered_set<std::string> &GetCurrentExternalLibDeps() const {
-    return storer_.current_external_lib_deps;
-  }
-  const internal::fs_unordered_set &GetCurrentIncludeDirs() const {
-    return storer_.current_include_dirs;
-  }
-  const internal::fs_unordered_set &GetCurrentLibDirs() const {
-    return storer_.current_lib_dirs;
-  }
-  const std::unordered_set<std::string> &GetCurrentPreprocessorFlags() const {
-    return storer_.current_preprocessor_flags;
-  }
-  const std::unordered_set<std::string> &GetCurrentCommonCompileFlags() const {
-    return storer_.current_common_compile_flags;
-  }
-  const std::unordered_set<std::string> &GetCurrentPchCompileFlags() const {
-    return storer_.current_pch_compile_flags;
-  }
-  const std::unordered_set<std::string> &GetCurrentPchObjectFlags() const {
-    return storer_.current_pch_object_flags;
-  }
-  const std::unordered_set<std::string> &GetCurrentAsmCompileFlags() const {
-    return storer_.current_asm_compile_flags;
-  }
-  const std::unordered_set<std::string> &GetCurrentCCompileFlags() const {
-    return storer_.current_c_compile_flags;
-  }
-  const std::unordered_set<std::string> &GetCurrentCppCompileFlags() const {
-    return storer_.current_cpp_compile_flags;
-  }
-  const std::unordered_set<std::string> &GetCurrentLinkFlags() const {
-    return storer_.current_link_flags;
-  }
-  const internal::fs_unordered_set &GetCurrentCompileDependencies() const {
-    return storer_.current_compile_dependencies.user;
-  }
-  const internal::fs_unordered_set &GetCurrentLinkDependencies() const {
-    return storer_.current_link_dependencies.user;
-  }
 
   // Getters (state_.ExpectsLock)
 

--- a/buildcc/lib/target/include/target/target.h
+++ b/buildcc/lib/target/include/target/target.h
@@ -77,7 +77,6 @@ public:
     Initialize();
   }
   virtual ~Target() {}
-
   Target(const Target &target) = delete;
 
   // Builders
@@ -85,15 +84,8 @@ public:
 
   // Getters (GENERIC)
 
-  // Set during first build or rebuild
-  // lock == true after Build is called
-  const TargetState &GetState() const { return state_; }
-  bool GetBuildState() const { return state_.build; }
-  bool GetLockState() const { return state_.lock; }
-
   // NOTE, We are constructing the path
   fs::path GetBinaryPath() const { return loader_.GetBinaryPath(); }
-
   const fs::path &GetTargetPath() const { return link_target_.GetOutput(); }
   const fs::path &GetPchHeaderPath() const {
     return compile_pch_.GetHeaderPath();

--- a/buildcc/lib/target/include/target/target.h
+++ b/buildcc/lib/target/include/target/target.h
@@ -155,7 +155,10 @@ private:
   // Fbs
   bool Store() override;
 
-  // Callbacks
+  // Tasks
+  void TaskDeps();
+
+  // Callbacks for unit tests
   void SourceRemoved();
   void SourceAdded();
   void SourceUpdated();
@@ -167,15 +170,13 @@ private:
   void FlagChanged();
   void ExternalLibChanged();
 
-  void TaskDeps();
-
 private:
   std::string name_;
   TargetType type_;
   const Toolchain &toolchain_;
   internal::TargetLoader loader_;
 
-  // Friend
+  // Friend classes
   CompilePch compile_pch_;
   CompileObject compile_object_;
   LinkTarget link_target_;

--- a/buildcc/lib/target/include/target/target_info.h
+++ b/buildcc/lib/target/include/target/target_info.h
@@ -30,7 +30,10 @@
 #include "target/api/include_api.h"
 #include "target/api/lib_api.h"
 #include "target/api/pch_api.h"
+
 #include "target/api/source_api.h"
+
+#include "target/api/target_info_getter.h"
 
 namespace buildcc::base {
 
@@ -41,19 +44,26 @@ class TargetInfo : public SourceApi<TargetInfo>,
                    public PchApi<TargetInfo>,
                    public FlagApi<TargetInfo>,
                    public DepsApi<TargetInfo>,
-                   public CopyApi<TargetInfo> {
+                   public CopyApi<TargetInfo>,
+                   public TargetInfoGetter<TargetInfo> {
 public:
   TargetInfo(const TargetEnv &env, const TargetConfig &config = TargetConfig())
       : env_(env), config_(config) {}
 
 private:
+  // Inputs
   friend class SourceApi<TargetInfo>;
   friend class IncludeApi<TargetInfo>;
   friend class LibApi<TargetInfo>;
   friend class PchApi<TargetInfo>;
   friend class FlagApi<TargetInfo>;
   friend class DepsApi<TargetInfo>;
+
+  // Feature
   friend class CopyApi<TargetInfo>;
+
+  // Getters
+  friend class TargetInfoGetter<TargetInfo>;
 
 protected:
   TargetEnv env_;

--- a/buildcc/lib/target/include/target/target_info.h
+++ b/buildcc/lib/target/include/target/target_info.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Niket Naidu. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TARGET_TARGET_INFO_H_
+#define TARGET_TARGET_INFO_H_
+
+#include <string>
+
+#include "target/common/target_config.h"
+#include "target/common/target_env.h"
+#include "target/common/target_state.h"
+#include "target/target_storer.h"
+
+#include "target/api/copy_api.h"
+#include "target/api/deps_api.h"
+#include "target/api/flag_api.h"
+#include "target/api/include_api.h"
+#include "target/api/lib_api.h"
+#include "target/api/pch_api.h"
+#include "target/api/source_api.h"
+
+namespace buildcc::base {
+
+//
+class TargetInfo : public SourceApi<TargetInfo>,
+                   public IncludeApi<TargetInfo>,
+                   public LibApi<TargetInfo>,
+                   public PchApi<TargetInfo>,
+                   public FlagApi<TargetInfo>,
+                   public DepsApi<TargetInfo>,
+                   public CopyApi<TargetInfo> {
+public:
+  TargetInfo(const TargetEnv &env, const TargetConfig &config = TargetConfig())
+      : env_(env), config_(config) {}
+
+private:
+  friend class SourceApi<TargetInfo>;
+  friend class IncludeApi<TargetInfo>;
+  friend class LibApi<TargetInfo>;
+  friend class PchApi<TargetInfo>;
+  friend class FlagApi<TargetInfo>;
+  friend class DepsApi<TargetInfo>;
+  friend class CopyApi<TargetInfo>;
+
+protected:
+  TargetEnv env_;
+  TargetConfig config_;
+
+  internal::TargetStorer storer_;
+  TargetState state_;
+};
+
+} // namespace buildcc::base
+
+#endif

--- a/buildcc/lib/target/include/target/target_info.h
+++ b/buildcc/lib/target/include/target/target_info.h
@@ -65,4 +65,10 @@ protected:
 
 } // namespace buildcc::base
 
+namespace buildcc {
+
+typedef base::TargetInfo TargetInfo;
+
+}
+
 #endif

--- a/buildcc/lib/target/src/api/copy_api.cpp
+++ b/buildcc/lib/target/src/api/copy_api.cpp
@@ -16,7 +16,7 @@
 
 #include "target/api/copy_api.h"
 
-#include "target/target.h"
+#include "target/target_info.h"
 
 namespace buildcc::base {
 
@@ -24,13 +24,13 @@ template <typename T>
 void CopyApi<T>::Copy(const T &target,
                       std::initializer_list<CopyOption> options) {
   env::log_trace(__FUNCTION__, "Copy by const ref");
-  SpecializedCopy<const Target &>(target, options);
+  SpecializedCopy<const T &>(target, options);
 }
 
 template <typename T>
 void CopyApi<T>::Copy(T &&target, std::initializer_list<CopyOption> options) {
   env::log_trace(__FUNCTION__, "Copy by move");
-  SpecializedCopy<Target &&>(std::move(target), options);
+  SpecializedCopy<T &&>(std::move(target), options);
 }
 
 // template <typename TargetType>
@@ -116,6 +116,6 @@ void CopyApi<T>::SpecializedCopy(TargetType target,
   }
 }
 
-template class CopyApi<Target>;
+template class CopyApi<TargetInfo>;
 
 } // namespace buildcc::base

--- a/buildcc/lib/target/src/api/deps_api.cpp
+++ b/buildcc/lib/target/src/api/deps_api.cpp
@@ -16,7 +16,7 @@
 
 #include "target/api/deps_api.h"
 
-#include "target/target.h"
+#include "target/target_info.h"
 
 namespace buildcc::base {
 
@@ -51,6 +51,6 @@ void DepsApi<T>::AddLinkDependency(const fs::path &relative_path) {
   AddLinkDependencyAbsolute(absolute_path);
 }
 
-template class DepsApi<Target>;
+template class DepsApi<TargetInfo>;
 
 } // namespace buildcc::base

--- a/buildcc/lib/target/src/api/flag_api.cpp
+++ b/buildcc/lib/target/src/api/flag_api.cpp
@@ -16,7 +16,7 @@
 
 #include "target/api/flag_api.h"
 
-#include "target/target.h"
+#include "target/target_info.h"
 
 namespace buildcc::base {
 
@@ -76,6 +76,6 @@ template <typename T> void FlagApi<T>::AddLinkFlag(const std::string &flag) {
   t.storer_.current_link_flags.insert(flag);
 }
 
-template class FlagApi<Target>;
+template class FlagApi<TargetInfo>;
 
 } // namespace buildcc::base

--- a/buildcc/lib/target/src/api/include_api.cpp
+++ b/buildcc/lib/target/src/api/include_api.cpp
@@ -16,7 +16,7 @@
 
 #include "target/api/include_api.h"
 
-#include "target/target.h"
+#include "target/target_info.h"
 
 namespace buildcc::base {
 
@@ -83,6 +83,6 @@ void IncludeApi<T>::AddIncludeDirAbsolute(const fs::path &absolute_include_dir,
   }
 }
 
-template class IncludeApi<Target>;
+template class IncludeApi<TargetInfo>;
 
 } // namespace buildcc::base

--- a/buildcc/lib/target/src/api/lib_api.cpp
+++ b/buildcc/lib/target/src/api/lib_api.cpp
@@ -17,6 +17,7 @@
 #include "target/api/lib_api.h"
 
 #include "target/target.h"
+#include "target/target_info.h"
 
 namespace buildcc::base {
 
@@ -50,6 +51,6 @@ template <typename T> void LibApi<T>::AddLibDep(const std::string &lib_dep) {
   t.storer_.current_external_lib_deps.insert(lib_dep);
 }
 
-template class LibApi<Target>;
+template class LibApi<TargetInfo>;
 
 } // namespace buildcc::base

--- a/buildcc/lib/target/src/api/pch_api.cpp
+++ b/buildcc/lib/target/src/api/pch_api.cpp
@@ -16,7 +16,7 @@
 
 #include "target/api/pch_api.h"
 
-#include "target/target.h"
+#include "target/target_info.h"
 
 namespace buildcc::base {
 
@@ -43,6 +43,6 @@ void PchApi<T>::AddPch(const fs::path &relative_filename,
   AddPchAbsolute(absolute_pch);
 }
 
-template class PchApi<Target>;
+template class PchApi<TargetInfo>;
 
 } // namespace buildcc::base

--- a/buildcc/lib/target/src/api/source_api.cpp
+++ b/buildcc/lib/target/src/api/source_api.cpp
@@ -16,7 +16,7 @@
 
 #include "target/api/source_api.h"
 
-#include "target/target.h"
+#include "target/target_info.h"
 
 namespace buildcc::base {
 
@@ -67,6 +67,6 @@ void SourceApi<T>::GlobSources(const fs::path &relative_to_target_path) {
 }
 
 //
-template class SourceApi<Target>;
+template class SourceApi<TargetInfo>;
 
 } // namespace buildcc::base

--- a/buildcc/lib/target/src/api/target_info_getter.cpp
+++ b/buildcc/lib/target/src/api/target_info_getter.cpp
@@ -20,6 +20,26 @@
 
 namespace buildcc::base {
 
+// Target State
+template <typename T> const TargetState &TargetInfoGetter<T>::GetState() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.state_;
+}
+
+template <typename T> bool TargetInfoGetter<T>::GetBuildState() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.state_.build;
+}
+
+template <typename T> bool TargetInfoGetter<T>::GetLockState() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.state_.lock;
+}
+
+// Target Storer
 template <typename T>
 const internal::fs_unordered_set &
 TargetInfoGetter<T>::GetCurrentSourceFiles() const {

--- a/buildcc/lib/target/src/api/target_info_getter.cpp
+++ b/buildcc/lib/target/src/api/target_info_getter.cpp
@@ -39,6 +39,29 @@ template <typename T> bool TargetInfoGetter<T>::GetLockState() const {
   return t.state_.lock;
 }
 
+// Target Env
+template <typename T>
+const fs::path &TargetInfoGetter<T>::GetTargetRootDir() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.env_.GetTargetRootDir();
+}
+
+template <typename T>
+const fs::path &TargetInfoGetter<T>::GetTargetBuildDir() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.env_.GetTargetBuildDir();
+}
+
+// Target Config
+template <typename T>
+const TargetConfig &TargetInfoGetter<T>::GetConfig() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.config_;
+}
+
 // Target Storer
 template <typename T>
 const internal::fs_unordered_set &

--- a/buildcc/lib/target/src/api/target_info_getter.cpp
+++ b/buildcc/lib/target/src/api/target_info_getter.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2021 Niket Naidu. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "target/api/target_info_getter.h"
+
+#include "target/target_info.h"
+
+namespace buildcc::base {
+
+template <typename T>
+const internal::fs_unordered_set &
+TargetInfoGetter<T>::GetCurrentSourceFiles() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_source_files.user;
+}
+
+template <typename T>
+const internal::fs_unordered_set &
+TargetInfoGetter<T>::GetCurrentHeaderFiles() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_header_files.user;
+}
+
+template <typename T>
+const internal::fs_unordered_set &
+TargetInfoGetter<T>::GetCurrentPchFiles() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_pch_files.user;
+}
+
+template <typename T>
+const internal::fs_unordered_set &
+TargetInfoGetter<T>::GetTargetLibDeps() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_lib_deps.user;
+}
+
+template <typename T>
+const std::unordered_set<std::string> &
+TargetInfoGetter<T>::GetCurrentExternalLibDeps() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_external_lib_deps;
+}
+
+template <typename T>
+const internal::fs_unordered_set &
+TargetInfoGetter<T>::GetCurrentIncludeDirs() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_include_dirs;
+}
+
+template <typename T>
+const internal::fs_unordered_set &
+TargetInfoGetter<T>::GetCurrentLibDirs() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_lib_dirs;
+}
+
+template <typename T>
+const std::unordered_set<std::string> &
+TargetInfoGetter<T>::GetCurrentPreprocessorFlags() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_preprocessor_flags;
+}
+
+template <typename T>
+const std::unordered_set<std::string> &
+TargetInfoGetter<T>::GetCurrentCommonCompileFlags() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_common_compile_flags;
+}
+
+template <typename T>
+const std::unordered_set<std::string> &
+TargetInfoGetter<T>::GetCurrentPchCompileFlags() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_pch_compile_flags;
+}
+
+template <typename T>
+const std::unordered_set<std::string> &
+TargetInfoGetter<T>::GetCurrentPchObjectFlags() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_pch_object_flags;
+}
+
+template <typename T>
+const std::unordered_set<std::string> &
+TargetInfoGetter<T>::GetCurrentAsmCompileFlags() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_asm_compile_flags;
+}
+
+template <typename T>
+const std::unordered_set<std::string> &
+TargetInfoGetter<T>::GetCurrentCCompileFlags() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_c_compile_flags;
+}
+
+template <typename T>
+const std::unordered_set<std::string> &
+TargetInfoGetter<T>::GetCurrentCppCompileFlags() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_cpp_compile_flags;
+}
+
+template <typename T>
+const std::unordered_set<std::string> &
+TargetInfoGetter<T>::GetCurrentLinkFlags() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_link_flags;
+}
+
+template <typename T>
+const internal::fs_unordered_set &
+TargetInfoGetter<T>::GetCurrentCompileDependencies() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_compile_dependencies.user;
+}
+
+template <typename T>
+const internal::fs_unordered_set &
+TargetInfoGetter<T>::GetCurrentLinkDependencies() const {
+  const T &t = static_cast<const T &>(*this);
+
+  return t.storer_.current_link_dependencies.user;
+}
+
+template class TargetInfoGetter<TargetInfo>;
+
+} // namespace buildcc::base


### PR DESCRIPTION
Basic Target Information class to hold input information.

Useful when 
- We need to store common information for multiple `Targets`
- Do not need to `Build` the Target, ex. Header only compilation units
