### PR TITLE
Custom generator groups

### DIFF
--- a/buildcc/lib/target/include/target/custom_generator.h
+++ b/buildcc/lib/target/include/target/custom_generator.h
@@ -193,6 +193,23 @@ private:
   struct GroupMetadata {
     std::vector<std::string> ids;
     DependencyCb dependency_cb;
+
+    void InvokeDependencyCb(const std::string &group_id,
+                            std::unordered_map<std::string, tf::Task>
+                                &&registered_tasks) const noexcept {
+      if (!dependency_cb) {
+        return;
+      }
+      try {
+        dependency_cb(std::move(registered_tasks));
+      } catch (...) {
+        env::log_critical(
+            __FUNCTION__,
+            fmt::format("Dependency callback failed for group id {}",
+                        group_id));
+        env::set_task_state(env::TaskState::FAILURE);
+      }
+    }
   };
 
 private:

--- a/buildcc/lib/target/include/target/custom_generator.h
+++ b/buildcc/lib/target/include/target/custom_generator.h
@@ -41,12 +41,14 @@ namespace buildcc {
 class CustomGeneratorContext {
 public:
   CustomGeneratorContext(const env::Command &c, const fs_unordered_set &i,
-                         const fs_unordered_set &o)
-      : command(c), inputs(i), outputs(o) {}
+                         const fs_unordered_set &o,
+                         const std::vector<uint8_t> &ub)
+      : command(c), inputs(i), outputs(o), userblob(ub) {}
 
   const env::Command &command;
   const fs_unordered_set &inputs;
   const fs_unordered_set &outputs;
+  const std::vector<uint8_t> &userblob;
 };
 
 // clang-format off

--- a/buildcc/lib/target/include/target/custom_generator.h
+++ b/buildcc/lib/target/include/target/custom_generator.h
@@ -99,8 +99,8 @@ struct UserCustomGeneratorSchema : public internal::CustomGeneratorSchema {
     for (auto &[id, gen_info] : gen_info_map) {
       gen_info.internal_inputs = path_schema_convert(
           gen_info.inputs, internal::Path::CreateExistingPath);
-      auto p = internal_gen_info_map.emplace(id, gen_info);
-      env::assert_fatal(p.second, fmt::format("Could not save {}", id));
+      auto [_, success] = internal_gen_info_map.try_emplace(id, gen_info);
+      env::assert_fatal(success, fmt::format("Could not save {}", id));
     }
   }
 };

--- a/buildcc/lib/target/include/target/custom_generator.h
+++ b/buildcc/lib/target/include/target/custom_generator.h
@@ -192,7 +192,8 @@ private:
   void IdUpdated();
 
 protected:
-  env::Command command_;
+  const env::Command &ConstCommand() const { return command_; }
+  env::Command &RefCommand() { return command_; }
 
 private:
   struct GroupMetadata {
@@ -231,6 +232,7 @@ private:
   std::unordered_map<std::string, UserGenInfo> success_schema_;
 
   // Internal
+  env::Command command_;
   tf::Taskflow tf_;
 
   // Callbacks

--- a/buildcc/lib/target/include/target/custom_generator.h
+++ b/buildcc/lib/target/include/target/custom_generator.h
@@ -181,6 +181,9 @@ private:
   void BuildGenerate(std::unordered_set<std::string> &gen_selected_ids,
                      std::unordered_set<std::string> &dummy_gen_selected_ids);
 
+  void InvokeDependencyCb(std::unordered_map<std::string, tf::Task>
+                              &&registered_tasks) const noexcept;
+
   // Recheck states
   void IdRemoved();
   void IdAdded();

--- a/buildcc/lib/target/include/target/file_generator.h
+++ b/buildcc/lib/target/include/target/file_generator.h
@@ -23,9 +23,8 @@ namespace buildcc {
 
 class FileGenerator : public CustomGenerator {
 public:
-  FileGenerator(const std::string &name, const TargetEnv &env)
-      : CustomGenerator(name, env) {}
-  virtual ~FileGenerator() = default;
+  using CustomGenerator::CustomGenerator;
+  ~FileGenerator() override = default;
   FileGenerator(const FileGenerator &) = delete;
 
   /**

--- a/buildcc/lib/target/include/target/file_generator.h
+++ b/buildcc/lib/target/include/target/file_generator.h
@@ -73,6 +73,7 @@ public:
 private:
   using CustomGenerator::AddDependencyCb;
   using CustomGenerator::AddGenInfo;
+  using CustomGenerator::AddGroup;
   using CustomGenerator::Build;
 
 private:

--- a/buildcc/lib/target/include/target/template_generator.h
+++ b/buildcc/lib/target/include/target/template_generator.h
@@ -23,8 +23,9 @@ namespace buildcc {
 
 class TemplateGenerator : public CustomGenerator {
 public:
-  TemplateGenerator(const std::string &name, const TargetEnv &env)
-      : CustomGenerator(name, env) {}
+  using CustomGenerator::CustomGenerator;
+  ~TemplateGenerator() override = default;
+  TemplateGenerator(const TemplateGenerator &) = delete;
 
   void AddTemplate(const fs::path &input_filename,
                    const fs::path &output_filename);

--- a/buildcc/lib/target/include/target/template_generator.h
+++ b/buildcc/lib/target/include/target/template_generator.h
@@ -41,6 +41,7 @@ public:
 private:
   using CustomGenerator::AddDependencyCb;
   using CustomGenerator::AddGenInfo;
+  using CustomGenerator::AddGroup;
   using CustomGenerator::Build;
 
 private:

--- a/buildcc/lib/target/include/target/template_generator.h
+++ b/buildcc/lib/target/include/target/template_generator.h
@@ -28,7 +28,7 @@ public:
 
   void AddTemplate(const fs::path &input_filename,
                    const fs::path &output_filename);
-  std::string Parse(const std::string &pattern);
+  std::string Parse(const std::string &pattern) const;
 
   /**
    * @brief Build FileGenerator Tasks

--- a/buildcc/lib/target/src/custom_generator/custom_generator.cpp
+++ b/buildcc/lib/target/src/custom_generator/custom_generator.cpp
@@ -200,17 +200,7 @@ void CustomGenerator::GenerateTask() {
           }
 
           // Dependency callback
-          if (group_metadata.dependency_cb) {
-            try {
-              group_metadata.dependency_cb(std::move(reg_tasks));
-            } catch (...) {
-              env::log_critical(
-                  __FUNCTION__,
-                  fmt::format("Dependency callback failed for group id {}",
-                              group_id));
-              env::set_task_state(env::TaskState::FAILURE);
-            }
-          }
+          group_metadata.InvokeDependencyCb(group_id, std::move(reg_tasks));
 
           // NOTE, Do not call detach otherwise this will fail
           s.join();

--- a/buildcc/lib/target/src/custom_generator/custom_generator.cpp
+++ b/buildcc/lib/target/src/custom_generator/custom_generator.cpp
@@ -301,7 +301,8 @@ void CustomGenerator::TaskRunner(bool run, const std::string &id) {
   if (rerun) {
     dirty_ = true;
     buildcc::CustomGeneratorContext ctx(command_, current_info.inputs,
-                                        current_info.outputs);
+                                        current_info.outputs,
+                                        current_info.userblob);
     bool success = current_info.generate_cb(ctx);
     env::assert_fatal(success, fmt::format("Generate Cb failed for id {}", id));
   }

--- a/buildcc/lib/target/src/generator/file_generator.cpp
+++ b/buildcc/lib/target/src/generator/file_generator.cpp
@@ -98,7 +98,7 @@ namespace buildcc {
 void FileGenerator::AddInput(const std::string &absolute_input_pattern,
                              const char *identifier) {
   std::string absolute_input_string =
-      command_.Construct(absolute_input_pattern);
+      RefCommand().Construct(absolute_input_pattern);
   const auto absolute_input_path =
       internal::Path::CreateNewPath(absolute_input_string);
   inputs_.insert(absolute_input_path.GetPathname());
@@ -111,7 +111,7 @@ void FileGenerator::AddInput(const std::string &absolute_input_pattern,
 void FileGenerator::AddOutput(const std::string &absolute_output_pattern,
                               const char *identifier) {
   std::string absolute_output_string =
-      command_.Construct(absolute_output_pattern);
+      RefCommand().Construct(absolute_output_pattern);
   const auto absolute_output_path =
       internal::Path::CreateNewPath(absolute_output_string);
   outputs_.insert(absolute_output_path.GetPathname());
@@ -125,7 +125,7 @@ void FileGenerator::AddCommand(
     const std::string &command_pattern,
     const std::unordered_map<const char *, std::string> &arguments) {
   std::string constructed_command =
-      command_.Construct(command_pattern, arguments);
+      RefCommand().Construct(command_pattern, arguments);
   commands_.emplace_back(std::move(constructed_command));
 }
 

--- a/buildcc/lib/target/src/generator/template_generator.cpp
+++ b/buildcc/lib/target/src/generator/template_generator.cpp
@@ -56,7 +56,7 @@ void TemplateGenerator::AddTemplate(const fs::path &input_filename,
   template_infos_.emplace_back(std::move(info));
 }
 
-std::string TemplateGenerator::Parse(const std::string &pattern) {
+std::string TemplateGenerator::Parse(const std::string &pattern) const {
   return command_.Construct(pattern);
 }
 

--- a/buildcc/lib/target/src/generator/template_generator.cpp
+++ b/buildcc/lib/target/src/generator/template_generator.cpp
@@ -48,16 +48,16 @@ void TemplateGenerator::AddTemplate(const fs::path &input_filename,
                                     const fs::path &output_filename) {
   TemplateInfo info;
   info.input = internal::Path::CreateNewPath(
-                   command_.Construct(path_as_string(input_filename)))
+                   RefCommand().Construct(path_as_string(input_filename)))
                    .GetPathname();
   info.output = internal::Path::CreateNewPath(
-                    command_.Construct(path_as_string(output_filename)))
+                    RefCommand().Construct(path_as_string(output_filename)))
                     .GetPathname();
   template_infos_.emplace_back(std::move(info));
 }
 
 std::string TemplateGenerator::Parse(const std::string &pattern) const {
-  return command_.Construct(pattern);
+  return ConstCommand().Construct(pattern);
 }
 
 /**

--- a/buildcc/lib/target/test/target/test_custom_generator.cpp
+++ b/buildcc/lib/target/test/target/test_custom_generator.cpp
@@ -746,6 +746,9 @@ TEST(CustomGeneratorTestGroup, RealGenerate_RemoveAndAdd) {
                     {"{gen_build_dir}/dummy_main.o"}, RealGenerateCb);
     cgen.AddGenInfo("id2", {"{gen_root_dir}/dummy_main.c"},
                     {"{gen_build_dir}/dummy_main.o"}, RealGenerateCb);
+    cgen.AddDependencyCb([](auto &&task_map) {
+      task_map.at("id1").precede(task_map.at("id2"));
+    });
     cgen.Build();
 
     buildcc::m::CustomGeneratorExpect_IdAdded(1, &cgen);
@@ -807,6 +810,9 @@ TEST(CustomGeneratorTestGroup, RealGenerate_Update_Failure) {
                     {"{gen_build_dir}/dummy_main.o"}, RealGenerateCb);
     cgen.AddGenInfo("id2", {"{gen_build_dir}/dummy_main.cpp"},
                     {"{gen_build_dir}/other_dummy_main.o"}, RealGenerateCb);
+    cgen.AddDependencyCb([](auto &&task_map) {
+      task_map.at("id1").precede(task_map.at("id2"));
+    });
     cgen.Build();
 
     mock().expectOneCall("RealGenerateCb");
@@ -840,6 +846,9 @@ TEST(CustomGeneratorTestGroup, RealGenerate_Update_Failure) {
                     {"{gen_build_dir}/dummy_main.o"}, RealGenerateCb);
     cgen.AddGenInfo("id2", {"{gen_build_dir}/dummy_main.cpp"},
                     {"{gen_build_dir}/other_dummy_main.o"}, RealGenerateCb);
+    cgen.AddDependencyCb([](auto &&task_map) {
+      task_map.at("id1").precede(task_map.at("id2"));
+    });
     cgen.Build();
 
     mock().expectOneCall("RealGenerateCb");


### PR DESCRIPTION
- Group subflows into a subflow group
- This can then be used by Target to create easy task dependencies